### PR TITLE
Handles lists, negated and wild card operators during match

### DIFF
--- a/grammar/apg-chunks.js
+++ b/grammar/apg-chunks.js
@@ -3,15 +3,15 @@ module.exports = function(){
 "use strict";
   //```
   // SUMMARY
-  //      rules = 36
+  //      rules = 40
   //       udts = 0
-  //    opcodes = 209
+  //    opcodes = 231
   //        ---   ABNF original opcodes
-  //        ALT = 14
-  //        CAT = 32
-  //        REP = 36
-  //        RNM = 75
-  //        TLS = 26
+  //        ALT = 16
+  //        CAT = 35
+  //        REP = 39
+  //        RNM = 85
+  //        TLS = 30
   //        TBS = 19
   //        TRG = 7
   //        ---   SABNF superset opcodes
@@ -42,30 +42,34 @@ module.exports = function(){
   this.rules[9] = {name: 'property', lower: 'property', index: 9, isBkr: false};
   this.rules[10] = {name: 'property-name', lower: 'property-name', index: 10, isBkr: false};
   this.rules[11] = {name: 'property-value', lower: 'property-value', index: 11, isBkr: false};
-  this.rules[12] = {name: 'value', lower: 'value', index: 12, isBkr: false};
-  this.rules[13] = {name: 'name', lower: 'name', index: 13, isBkr: false};
-  this.rules[14] = {name: 'number', lower: 'number', index: 14, isBkr: false};
-  this.rules[15] = {name: 'decimal-point', lower: 'decimal-point', index: 15, isBkr: false};
-  this.rules[16] = {name: 'digit1-9', lower: 'digit1-9', index: 16, isBkr: false};
-  this.rules[17] = {name: 'e', lower: 'e', index: 17, isBkr: false};
-  this.rules[18] = {name: 'exp', lower: 'exp', index: 18, isBkr: false};
-  this.rules[19] = {name: 'frac', lower: 'frac', index: 19, isBkr: false};
-  this.rules[20] = {name: 'int', lower: 'int', index: 20, isBkr: false};
-  this.rules[21] = {name: 'minus', lower: 'minus', index: 21, isBkr: false};
-  this.rules[22] = {name: 'plus', lower: 'plus', index: 22, isBkr: false};
-  this.rules[23] = {name: 'zero', lower: 'zero', index: 23, isBkr: false};
-  this.rules[24] = {name: 'string', lower: 'string', index: 24, isBkr: false};
-  this.rules[25] = {name: 'char', lower: 'char', index: 25, isBkr: false};
-  this.rules[26] = {name: 'escape', lower: 'escape', index: 26, isBkr: false};
-  this.rules[27] = {name: 'quotation-mark', lower: 'quotation-mark', index: 27, isBkr: false};
-  this.rules[28] = {name: 'unescaped', lower: 'unescaped', index: 28, isBkr: false};
-  this.rules[29] = {name: 'ws', lower: 'ws', index: 29, isBkr: false};
-  this.rules[30] = {name: 'sep', lower: 'sep', index: 30, isBkr: false};
-  this.rules[31] = {name: 'begin-properties', lower: 'begin-properties', index: 31, isBkr: false};
-  this.rules[32] = {name: 'end-properties', lower: 'end-properties', index: 32, isBkr: false};
-  this.rules[33] = {name: 'ALPHA', lower: 'alpha', index: 33, isBkr: false};
-  this.rules[34] = {name: 'DIGIT', lower: 'digit', index: 34, isBkr: false};
-  this.rules[35] = {name: 'HEXDIG', lower: 'hexdig', index: 35, isBkr: false};
+  this.rules[12] = {name: 'name', lower: 'name', index: 12, isBkr: false};
+  this.rules[13] = {name: 'reserved-name', lower: 'reserved-name', index: 13, isBkr: false};
+  this.rules[14] = {name: 'negated', lower: 'negated', index: 14, isBkr: false};
+  this.rules[15] = {name: 'variable', lower: 'variable', index: 15, isBkr: false};
+  this.rules[16] = {name: 'inner-name', lower: 'inner-name', index: 16, isBkr: false};
+  this.rules[17] = {name: 'value', lower: 'value', index: 17, isBkr: false};
+  this.rules[18] = {name: 'number', lower: 'number', index: 18, isBkr: false};
+  this.rules[19] = {name: 'decimal-point', lower: 'decimal-point', index: 19, isBkr: false};
+  this.rules[20] = {name: 'digit1-9', lower: 'digit1-9', index: 20, isBkr: false};
+  this.rules[21] = {name: 'e', lower: 'e', index: 21, isBkr: false};
+  this.rules[22] = {name: 'exp', lower: 'exp', index: 22, isBkr: false};
+  this.rules[23] = {name: 'frac', lower: 'frac', index: 23, isBkr: false};
+  this.rules[24] = {name: 'int', lower: 'int', index: 24, isBkr: false};
+  this.rules[25] = {name: 'minus', lower: 'minus', index: 25, isBkr: false};
+  this.rules[26] = {name: 'plus', lower: 'plus', index: 26, isBkr: false};
+  this.rules[27] = {name: 'zero', lower: 'zero', index: 27, isBkr: false};
+  this.rules[28] = {name: 'string', lower: 'string', index: 28, isBkr: false};
+  this.rules[29] = {name: 'char', lower: 'char', index: 29, isBkr: false};
+  this.rules[30] = {name: 'escape', lower: 'escape', index: 30, isBkr: false};
+  this.rules[31] = {name: 'quotation-mark', lower: 'quotation-mark', index: 31, isBkr: false};
+  this.rules[32] = {name: 'unescaped', lower: 'unescaped', index: 32, isBkr: false};
+  this.rules[33] = {name: 'ws', lower: 'ws', index: 33, isBkr: false};
+  this.rules[34] = {name: 'sep', lower: 'sep', index: 34, isBkr: false};
+  this.rules[35] = {name: 'begin-properties', lower: 'begin-properties', index: 35, isBkr: false};
+  this.rules[36] = {name: 'end-properties', lower: 'end-properties', index: 36, isBkr: false};
+  this.rules[37] = {name: 'ALPHA', lower: 'alpha', index: 37, isBkr: false};
+  this.rules[38] = {name: 'DIGIT', lower: 'digit', index: 38, isBkr: false};
+  this.rules[39] = {name: 'HEXDIG', lower: 'hexdig', index: 39, isBkr: false};
 
   /* UDTS */
   this.udts = [];
@@ -75,17 +79,17 @@ module.exports = function(){
   this.rules[0].opcodes = [];
   this.rules[0].opcodes[0] = {type: 2, children: [1,3,5]};// CAT
   this.rules[0].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[0].opcodes[2] = {type: 4, index: 29};// RNM(ws)
+  this.rules[0].opcodes[2] = {type: 4, index: 33};// RNM(ws)
   this.rules[0].opcodes[3] = {type: 3, min: 0, max: 1};// REP
   this.rules[0].opcodes[4] = {type: 4, index: 1};// RNM(statements)
   this.rules[0].opcodes[5] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[0].opcodes[6] = {type: 4, index: 29};// RNM(ws)
+  this.rules[0].opcodes[6] = {type: 4, index: 33};// RNM(ws)
 
   /* statements */
   this.rules[1].opcodes = [];
   this.rules[1].opcodes[0] = {type: 2, children: [1,3]};// CAT
   this.rules[1].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[1].opcodes[2] = {type: 4, index: 29};// RNM(ws)
+  this.rules[1].opcodes[2] = {type: 4, index: 33};// RNM(ws)
   this.rules[1].opcodes[3] = {type: 1, children: [4,10,14,18]};// ALT
   this.rules[1].opcodes[4] = {type: 2, children: [5,6]};// CAT
   this.rules[1].opcodes[5] = {type: 4, index: 2};// RNM(comment)
@@ -105,7 +109,7 @@ module.exports = function(){
   this.rules[1].opcodes[19] = {type: 4, index: 5};// RNM(compact-link)
   this.rules[1].opcodes[20] = {type: 3, min: 0, max: 1};// REP
   this.rules[1].opcodes[21] = {type: 2, children: [22,23]};// CAT
-  this.rules[1].opcodes[22] = {type: 4, index: 29};// RNM(ws)
+  this.rules[1].opcodes[22] = {type: 4, index: 33};// RNM(ws)
   this.rules[1].opcodes[23] = {type: 4, index: 1};// RNM(statements)
 
   /* comment */
@@ -113,7 +117,7 @@ module.exports = function(){
   this.rules[2].opcodes[0] = {type: 2, children: [1,2]};// CAT
   this.rules[2].opcodes[1] = {type: 7, string: [35]};// TLS
   this.rules[2].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[2].opcodes[3] = {type: 4, index: 25};// RNM(char)
+  this.rules[2].opcodes[3] = {type: 4, index: 29};// RNM(char)
 
   /* chunk */
   this.rules[3].opcodes = [];
@@ -121,45 +125,47 @@ module.exports = function(){
   this.rules[3].opcodes[1] = {type: 4, index: 6};// RNM(type)
   this.rules[3].opcodes[2] = {type: 3, min: 0, max: 1};// REP
   this.rules[3].opcodes[3] = {type: 2, children: [4,5]};// CAT
-  this.rules[3].opcodes[4] = {type: 4, index: 29};// RNM(ws)
+  this.rules[3].opcodes[4] = {type: 4, index: 33};// RNM(ws)
   this.rules[3].opcodes[5] = {type: 4, index: 7};// RNM(id)
-  this.rules[3].opcodes[6] = {type: 4, index: 31};// RNM(begin-properties)
+  this.rules[3].opcodes[6] = {type: 4, index: 35};// RNM(begin-properties)
   this.rules[3].opcodes[7] = {type: 3, min: 0, max: 1};// REP
   this.rules[3].opcodes[8] = {type: 4, index: 8};// RNM(properties)
-  this.rules[3].opcodes[9] = {type: 4, index: 32};// RNM(end-properties)
+  this.rules[3].opcodes[9] = {type: 4, index: 36};// RNM(end-properties)
 
   /* compact-rule */
   this.rules[4].opcodes = [];
-  this.rules[4].opcodes[0] = {type: 2, children: [1,2,3,4]};// CAT
-  this.rules[4].opcodes[1] = {type: 4, index: 3};// RNM(chunk)
-  this.rules[4].opcodes[2] = {type: 7, string: [61,62]};// TLS
+  this.rules[4].opcodes[0] = {type: 2, children: [1,3,4,5,6]};// CAT
+  this.rules[4].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[4].opcodes[2] = {type: 7, string: [33]};// TLS
   this.rules[4].opcodes[3] = {type: 4, index: 3};// RNM(chunk)
-  this.rules[4].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[4].opcodes[5] = {type: 2, children: [6,7]};// CAT
-  this.rules[4].opcodes[6] = {type: 7, string: [44]};// TLS
-  this.rules[4].opcodes[7] = {type: 4, index: 3};// RNM(chunk)
+  this.rules[4].opcodes[4] = {type: 7, string: [61,62]};// TLS
+  this.rules[4].opcodes[5] = {type: 4, index: 3};// RNM(chunk)
+  this.rules[4].opcodes[6] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[4].opcodes[7] = {type: 2, children: [8,9]};// CAT
+  this.rules[4].opcodes[8] = {type: 7, string: [44]};// TLS
+  this.rules[4].opcodes[9] = {type: 4, index: 3};// RNM(chunk)
 
   /* compact-link */
   this.rules[5].opcodes = [];
   this.rules[5].opcodes[0] = {type: 2, children: [1,2,3,4,5]};// CAT
   this.rules[5].opcodes[1] = {type: 4, index: 7};// RNM(id)
-  this.rules[5].opcodes[2] = {type: 4, index: 29};// RNM(ws)
+  this.rules[5].opcodes[2] = {type: 4, index: 33};// RNM(ws)
   this.rules[5].opcodes[3] = {type: 4, index: 10};// RNM(property-name)
-  this.rules[5].opcodes[4] = {type: 4, index: 29};// RNM(ws)
+  this.rules[5].opcodes[4] = {type: 4, index: 33};// RNM(ws)
   this.rules[5].opcodes[5] = {type: 4, index: 7};// RNM(id)
 
   /* type */
   this.rules[6].opcodes = [];
   this.rules[6].opcodes[0] = {type: 2, children: [1,3]};// CAT
   this.rules[6].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[6].opcodes[2] = {type: 4, index: 29};// RNM(ws)
+  this.rules[6].opcodes[2] = {type: 4, index: 33};// RNM(ws)
   this.rules[6].opcodes[3] = {type: 1, children: [4,5]};// ALT
   this.rules[6].opcodes[4] = {type: 7, string: [42]};// TLS
-  this.rules[6].opcodes[5] = {type: 4, index: 13};// RNM(name)
+  this.rules[6].opcodes[5] = {type: 4, index: 12};// RNM(name)
 
   /* id */
   this.rules[7].opcodes = [];
-  this.rules[7].opcodes[0] = {type: 4, index: 13};// RNM(name)
+  this.rules[7].opcodes[0] = {type: 4, index: 12};// RNM(name)
 
   /* properties */
   this.rules[8].opcodes = [];
@@ -167,315 +173,351 @@ module.exports = function(){
   this.rules[8].opcodes[1] = {type: 4, index: 9};// RNM(property)
   this.rules[8].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
   this.rules[8].opcodes[3] = {type: 2, children: [4,5]};// CAT
-  this.rules[8].opcodes[4] = {type: 4, index: 30};// RNM(sep)
+  this.rules[8].opcodes[4] = {type: 4, index: 34};// RNM(sep)
   this.rules[8].opcodes[5] = {type: 4, index: 9};// RNM(property)
 
   /* property */
   this.rules[9].opcodes = [];
   this.rules[9].opcodes[0] = {type: 2, children: [1,2,3]};// CAT
   this.rules[9].opcodes[1] = {type: 4, index: 10};// RNM(property-name)
-  this.rules[9].opcodes[2] = {type: 4, index: 29};// RNM(ws)
+  this.rules[9].opcodes[2] = {type: 4, index: 33};// RNM(ws)
   this.rules[9].opcodes[3] = {type: 4, index: 11};// RNM(property-value)
 
   /* property-name */
   this.rules[10].opcodes = [];
-  this.rules[10].opcodes[0] = {type: 4, index: 13};// RNM(name)
+  this.rules[10].opcodes[0] = {type: 1, children: [1,2]};// ALT
+  this.rules[10].opcodes[1] = {type: 4, index: 12};// RNM(name)
+  this.rules[10].opcodes[2] = {type: 4, index: 13};// RNM(reserved-name)
 
   /* property-value */
   this.rules[11].opcodes = [];
   this.rules[11].opcodes[0] = {type: 2, children: [1,2]};// CAT
-  this.rules[11].opcodes[1] = {type: 4, index: 12};// RNM(value)
+  this.rules[11].opcodes[1] = {type: 4, index: 17};// RNM(value)
   this.rules[11].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
   this.rules[11].opcodes[3] = {type: 2, children: [4,5]};// CAT
   this.rules[11].opcodes[4] = {type: 7, string: [44]};// TLS
-  this.rules[11].opcodes[5] = {type: 4, index: 12};// RNM(value)
-
-  /* value */
-  this.rules[12].opcodes = [];
-  this.rules[12].opcodes[0] = {type: 2, children: [1,3,9]};// CAT
-  this.rules[12].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[12].opcodes[2] = {type: 4, index: 29};// RNM(ws)
-  this.rules[12].opcodes[3] = {type: 1, children: [4,5,6,7,8]};// ALT
-  this.rules[12].opcodes[4] = {type: 7, string: [102,97,108,115,101]};// TLS
-  this.rules[12].opcodes[5] = {type: 7, string: [116,114,117,101]};// TLS
-  this.rules[12].opcodes[6] = {type: 4, index: 13};// RNM(name)
-  this.rules[12].opcodes[7] = {type: 4, index: 14};// RNM(number)
-  this.rules[12].opcodes[8] = {type: 4, index: 24};// RNM(string)
-  this.rules[12].opcodes[9] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[12].opcodes[10] = {type: 4, index: 29};// RNM(ws)
+  this.rules[11].opcodes[5] = {type: 4, index: 17};// RNM(value)
 
   /* name */
+  this.rules[12].opcodes = [];
+  this.rules[12].opcodes[0] = {type: 2, children: [1,3,4]};// CAT
+  this.rules[12].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[12].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[12].opcodes[3] = {type: 4, index: 16};// RNM(inner-name)
+  this.rules[12].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[12].opcodes[5] = {type: 4, index: 33};// RNM(ws)
+
+  /* reserved-name */
   this.rules[13].opcodes = [];
-  this.rules[13].opcodes[0] = {type: 2, children: [1,3,5,14]};// CAT
+  this.rules[13].opcodes[0] = {type: 2, children: [1,3,4,5]};// CAT
   this.rules[13].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[13].opcodes[2] = {type: 4, index: 29};// RNM(ws)
-  this.rules[13].opcodes[3] = {type: 3, min: 0, max: 1};// REP
-  this.rules[13].opcodes[4] = {type: 7, string: [64]};// TLS
-  this.rules[13].opcodes[5] = {type: 3, min: 1, max: Infinity};// REP
-  this.rules[13].opcodes[6] = {type: 1, children: [7,8,9,10,11,12,13]};// ALT
-  this.rules[13].opcodes[7] = {type: 4, index: 33};// RNM(ALPHA)
-  this.rules[13].opcodes[8] = {type: 4, index: 34};// RNM(DIGIT)
-  this.rules[13].opcodes[9] = {type: 7, string: [46]};// TLS
-  this.rules[13].opcodes[10] = {type: 7, string: [95]};// TLS
-  this.rules[13].opcodes[11] = {type: 7, string: [45]};// TLS
-  this.rules[13].opcodes[12] = {type: 7, string: [47]};// TLS
-  this.rules[13].opcodes[13] = {type: 7, string: [58]};// TLS
-  this.rules[13].opcodes[14] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[13].opcodes[15] = {type: 4, index: 29};// RNM(ws)
+  this.rules[13].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[13].opcodes[3] = {type: 7, string: [64]};// TLS
+  this.rules[13].opcodes[4] = {type: 4, index: 16};// RNM(inner-name)
+  this.rules[13].opcodes[5] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[13].opcodes[6] = {type: 4, index: 33};// RNM(ws)
+
+  /* negated */
+  this.rules[14].opcodes = [];
+  this.rules[14].opcodes[0] = {type: 2, children: [1,2]};// CAT
+  this.rules[14].opcodes[1] = {type: 7, string: [33]};// TLS
+  this.rules[14].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[14].opcodes[3] = {type: 1, children: [4,5]};// ALT
+  this.rules[14].opcodes[4] = {type: 4, index: 16};// RNM(inner-name)
+  this.rules[14].opcodes[5] = {type: 4, index: 15};// RNM(variable)
+
+  /* variable */
+  this.rules[15].opcodes = [];
+  this.rules[15].opcodes[0] = {type: 2, children: [1,2]};// CAT
+  this.rules[15].opcodes[1] = {type: 7, string: [63]};// TLS
+  this.rules[15].opcodes[2] = {type: 4, index: 16};// RNM(inner-name)
+
+  /* inner-name */
+  this.rules[16].opcodes = [];
+  this.rules[16].opcodes[0] = {type: 3, min: 1, max: Infinity};// REP
+  this.rules[16].opcodes[1] = {type: 1, children: [2,3,4,5,6,7,8]};// ALT
+  this.rules[16].opcodes[2] = {type: 4, index: 37};// RNM(ALPHA)
+  this.rules[16].opcodes[3] = {type: 4, index: 38};// RNM(DIGIT)
+  this.rules[16].opcodes[4] = {type: 7, string: [46]};// TLS
+  this.rules[16].opcodes[5] = {type: 7, string: [95]};// TLS
+  this.rules[16].opcodes[6] = {type: 7, string: [45]};// TLS
+  this.rules[16].opcodes[7] = {type: 7, string: [47]};// TLS
+  this.rules[16].opcodes[8] = {type: 7, string: [58]};// TLS
+
+  /* value */
+  this.rules[17].opcodes = [];
+  this.rules[17].opcodes[0] = {type: 2, children: [1,3,12]};// CAT
+  this.rules[17].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[17].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[17].opcodes[3] = {type: 1, children: [4,5,6,7,8,9,10,11]};// ALT
+  this.rules[17].opcodes[4] = {type: 7, string: [42]};// TLS
+  this.rules[17].opcodes[5] = {type: 7, string: [102,97,108,115,101]};// TLS
+  this.rules[17].opcodes[6] = {type: 7, string: [116,114,117,101]};// TLS
+  this.rules[17].opcodes[7] = {type: 4, index: 16};// RNM(inner-name)
+  this.rules[17].opcodes[8] = {type: 4, index: 15};// RNM(variable)
+  this.rules[17].opcodes[9] = {type: 4, index: 14};// RNM(negated)
+  this.rules[17].opcodes[10] = {type: 4, index: 18};// RNM(number)
+  this.rules[17].opcodes[11] = {type: 4, index: 28};// RNM(string)
+  this.rules[17].opcodes[12] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[17].opcodes[13] = {type: 4, index: 33};// RNM(ws)
 
   /* number */
-  this.rules[14].opcodes = [];
-  this.rules[14].opcodes[0] = {type: 2, children: [1,3,4,6]};// CAT
-  this.rules[14].opcodes[1] = {type: 3, min: 0, max: 1};// REP
-  this.rules[14].opcodes[2] = {type: 4, index: 21};// RNM(minus)
-  this.rules[14].opcodes[3] = {type: 4, index: 20};// RNM(int)
-  this.rules[14].opcodes[4] = {type: 3, min: 0, max: 1};// REP
-  this.rules[14].opcodes[5] = {type: 4, index: 19};// RNM(frac)
-  this.rules[14].opcodes[6] = {type: 3, min: 0, max: 1};// REP
-  this.rules[14].opcodes[7] = {type: 4, index: 18};// RNM(exp)
+  this.rules[18].opcodes = [];
+  this.rules[18].opcodes[0] = {type: 2, children: [1,3,4,6]};// CAT
+  this.rules[18].opcodes[1] = {type: 3, min: 0, max: 1};// REP
+  this.rules[18].opcodes[2] = {type: 4, index: 25};// RNM(minus)
+  this.rules[18].opcodes[3] = {type: 4, index: 24};// RNM(int)
+  this.rules[18].opcodes[4] = {type: 3, min: 0, max: 1};// REP
+  this.rules[18].opcodes[5] = {type: 4, index: 23};// RNM(frac)
+  this.rules[18].opcodes[6] = {type: 3, min: 0, max: 1};// REP
+  this.rules[18].opcodes[7] = {type: 4, index: 22};// RNM(exp)
 
   /* decimal-point */
-  this.rules[15].opcodes = [];
-  this.rules[15].opcodes[0] = {type: 7, string: [46]};// TLS
+  this.rules[19].opcodes = [];
+  this.rules[19].opcodes[0] = {type: 7, string: [46]};// TLS
 
   /* digit1-9 */
-  this.rules[16].opcodes = [];
-  this.rules[16].opcodes[0] = {type: 5, min: 49, max: 57};// TRG
+  this.rules[20].opcodes = [];
+  this.rules[20].opcodes[0] = {type: 5, min: 49, max: 57};// TRG
 
   /* e */
-  this.rules[17].opcodes = [];
-  this.rules[17].opcodes[0] = {type: 1, children: [1,2]};// ALT
-  this.rules[17].opcodes[1] = {type: 6, string: [101]};// TBS
-  this.rules[17].opcodes[2] = {type: 6, string: [69]};// TBS
+  this.rules[21].opcodes = [];
+  this.rules[21].opcodes[0] = {type: 1, children: [1,2]};// ALT
+  this.rules[21].opcodes[1] = {type: 6, string: [101]};// TBS
+  this.rules[21].opcodes[2] = {type: 6, string: [69]};// TBS
 
   /* exp */
-  this.rules[18].opcodes = [];
-  this.rules[18].opcodes[0] = {type: 2, children: [1,2,6]};// CAT
-  this.rules[18].opcodes[1] = {type: 4, index: 17};// RNM(e)
-  this.rules[18].opcodes[2] = {type: 3, min: 0, max: 1};// REP
-  this.rules[18].opcodes[3] = {type: 1, children: [4,5]};// ALT
-  this.rules[18].opcodes[4] = {type: 4, index: 21};// RNM(minus)
-  this.rules[18].opcodes[5] = {type: 4, index: 22};// RNM(plus)
-  this.rules[18].opcodes[6] = {type: 3, min: 1, max: Infinity};// REP
-  this.rules[18].opcodes[7] = {type: 4, index: 34};// RNM(DIGIT)
+  this.rules[22].opcodes = [];
+  this.rules[22].opcodes[0] = {type: 2, children: [1,2,6]};// CAT
+  this.rules[22].opcodes[1] = {type: 4, index: 21};// RNM(e)
+  this.rules[22].opcodes[2] = {type: 3, min: 0, max: 1};// REP
+  this.rules[22].opcodes[3] = {type: 1, children: [4,5]};// ALT
+  this.rules[22].opcodes[4] = {type: 4, index: 25};// RNM(minus)
+  this.rules[22].opcodes[5] = {type: 4, index: 26};// RNM(plus)
+  this.rules[22].opcodes[6] = {type: 3, min: 1, max: Infinity};// REP
+  this.rules[22].opcodes[7] = {type: 4, index: 38};// RNM(DIGIT)
 
   /* frac */
-  this.rules[19].opcodes = [];
-  this.rules[19].opcodes[0] = {type: 2, children: [1,2]};// CAT
-  this.rules[19].opcodes[1] = {type: 4, index: 15};// RNM(decimal-point)
-  this.rules[19].opcodes[2] = {type: 3, min: 1, max: Infinity};// REP
-  this.rules[19].opcodes[3] = {type: 4, index: 34};// RNM(DIGIT)
+  this.rules[23].opcodes = [];
+  this.rules[23].opcodes[0] = {type: 2, children: [1,2]};// CAT
+  this.rules[23].opcodes[1] = {type: 4, index: 19};// RNM(decimal-point)
+  this.rules[23].opcodes[2] = {type: 3, min: 1, max: Infinity};// REP
+  this.rules[23].opcodes[3] = {type: 4, index: 38};// RNM(DIGIT)
 
   /* int */
-  this.rules[20].opcodes = [];
-  this.rules[20].opcodes[0] = {type: 1, children: [1,2]};// ALT
-  this.rules[20].opcodes[1] = {type: 4, index: 23};// RNM(zero)
-  this.rules[20].opcodes[2] = {type: 2, children: [3,4]};// CAT
-  this.rules[20].opcodes[3] = {type: 4, index: 16};// RNM(digit1-9)
-  this.rules[20].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[20].opcodes[5] = {type: 4, index: 34};// RNM(DIGIT)
+  this.rules[24].opcodes = [];
+  this.rules[24].opcodes[0] = {type: 1, children: [1,2]};// ALT
+  this.rules[24].opcodes[1] = {type: 4, index: 27};// RNM(zero)
+  this.rules[24].opcodes[2] = {type: 2, children: [3,4]};// CAT
+  this.rules[24].opcodes[3] = {type: 4, index: 20};// RNM(digit1-9)
+  this.rules[24].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[24].opcodes[5] = {type: 4, index: 38};// RNM(DIGIT)
 
   /* minus */
-  this.rules[21].opcodes = [];
-  this.rules[21].opcodes[0] = {type: 7, string: [45]};// TLS
+  this.rules[25].opcodes = [];
+  this.rules[25].opcodes[0] = {type: 7, string: [45]};// TLS
 
   /* plus */
-  this.rules[22].opcodes = [];
-  this.rules[22].opcodes[0] = {type: 7, string: [43]};// TLS
+  this.rules[26].opcodes = [];
+  this.rules[26].opcodes[0] = {type: 7, string: [43]};// TLS
 
   /* zero */
-  this.rules[23].opcodes = [];
-  this.rules[23].opcodes[0] = {type: 7, string: [48]};// TLS
+  this.rules[27].opcodes = [];
+  this.rules[27].opcodes[0] = {type: 7, string: [48]};// TLS
 
   /* string */
-  this.rules[24].opcodes = [];
-  this.rules[24].opcodes[0] = {type: 2, children: [1,2,4]};// CAT
-  this.rules[24].opcodes[1] = {type: 4, index: 27};// RNM(quotation-mark)
-  this.rules[24].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[24].opcodes[3] = {type: 4, index: 25};// RNM(char)
-  this.rules[24].opcodes[4] = {type: 4, index: 27};// RNM(quotation-mark)
+  this.rules[28].opcodes = [];
+  this.rules[28].opcodes[0] = {type: 2, children: [1,2,4]};// CAT
+  this.rules[28].opcodes[1] = {type: 4, index: 31};// RNM(quotation-mark)
+  this.rules[28].opcodes[2] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[28].opcodes[3] = {type: 4, index: 29};// RNM(char)
+  this.rules[28].opcodes[4] = {type: 4, index: 31};// RNM(quotation-mark)
 
   /* char */
-  this.rules[25].opcodes = [];
-  this.rules[25].opcodes[0] = {type: 1, children: [1,2]};// ALT
-  this.rules[25].opcodes[1] = {type: 4, index: 28};// RNM(unescaped)
-  this.rules[25].opcodes[2] = {type: 2, children: [3,4]};// CAT
-  this.rules[25].opcodes[3] = {type: 4, index: 26};// RNM(escape)
-  this.rules[25].opcodes[4] = {type: 1, children: [5,6,7,8,9,10,11,12,13]};// ALT
-  this.rules[25].opcodes[5] = {type: 6, string: [34]};// TBS
-  this.rules[25].opcodes[6] = {type: 6, string: [92]};// TBS
-  this.rules[25].opcodes[7] = {type: 6, string: [47]};// TBS
-  this.rules[25].opcodes[8] = {type: 6, string: [98]};// TBS
-  this.rules[25].opcodes[9] = {type: 6, string: [102]};// TBS
-  this.rules[25].opcodes[10] = {type: 6, string: [110]};// TBS
-  this.rules[25].opcodes[11] = {type: 6, string: [114]};// TBS
-  this.rules[25].opcodes[12] = {type: 6, string: [116]};// TBS
-  this.rules[25].opcodes[13] = {type: 2, children: [14,15]};// CAT
-  this.rules[25].opcodes[14] = {type: 6, string: [117]};// TBS
-  this.rules[25].opcodes[15] = {type: 3, min: 4, max: 4};// REP
-  this.rules[25].opcodes[16] = {type: 4, index: 35};// RNM(HEXDIG)
+  this.rules[29].opcodes = [];
+  this.rules[29].opcodes[0] = {type: 1, children: [1,2]};// ALT
+  this.rules[29].opcodes[1] = {type: 4, index: 32};// RNM(unescaped)
+  this.rules[29].opcodes[2] = {type: 2, children: [3,4]};// CAT
+  this.rules[29].opcodes[3] = {type: 4, index: 30};// RNM(escape)
+  this.rules[29].opcodes[4] = {type: 1, children: [5,6,7,8,9,10,11,12,13]};// ALT
+  this.rules[29].opcodes[5] = {type: 6, string: [34]};// TBS
+  this.rules[29].opcodes[6] = {type: 6, string: [92]};// TBS
+  this.rules[29].opcodes[7] = {type: 6, string: [47]};// TBS
+  this.rules[29].opcodes[8] = {type: 6, string: [98]};// TBS
+  this.rules[29].opcodes[9] = {type: 6, string: [102]};// TBS
+  this.rules[29].opcodes[10] = {type: 6, string: [110]};// TBS
+  this.rules[29].opcodes[11] = {type: 6, string: [114]};// TBS
+  this.rules[29].opcodes[12] = {type: 6, string: [116]};// TBS
+  this.rules[29].opcodes[13] = {type: 2, children: [14,15]};// CAT
+  this.rules[29].opcodes[14] = {type: 6, string: [117]};// TBS
+  this.rules[29].opcodes[15] = {type: 3, min: 4, max: 4};// REP
+  this.rules[29].opcodes[16] = {type: 4, index: 39};// RNM(HEXDIG)
 
   /* escape */
-  this.rules[26].opcodes = [];
-  this.rules[26].opcodes[0] = {type: 6, string: [92]};// TBS
+  this.rules[30].opcodes = [];
+  this.rules[30].opcodes[0] = {type: 6, string: [92]};// TBS
 
   /* quotation-mark */
-  this.rules[27].opcodes = [];
-  this.rules[27].opcodes[0] = {type: 6, string: [34]};// TBS
+  this.rules[31].opcodes = [];
+  this.rules[31].opcodes[0] = {type: 6, string: [34]};// TBS
 
   /* unescaped */
-  this.rules[28].opcodes = [];
-  this.rules[28].opcodes[0] = {type: 1, children: [1,2,3]};// ALT
-  this.rules[28].opcodes[1] = {type: 5, min: 32, max: 33};// TRG
-  this.rules[28].opcodes[2] = {type: 5, min: 35, max: 91};// TRG
-  this.rules[28].opcodes[3] = {type: 5, min: 93, max: 1114111};// TRG
+  this.rules[32].opcodes = [];
+  this.rules[32].opcodes[0] = {type: 1, children: [1,2,3]};// ALT
+  this.rules[32].opcodes[1] = {type: 5, min: 32, max: 33};// TRG
+  this.rules[32].opcodes[2] = {type: 5, min: 35, max: 91};// TRG
+  this.rules[32].opcodes[3] = {type: 5, min: 93, max: 1114111};// TRG
 
   /* ws */
-  this.rules[29].opcodes = [];
-  this.rules[29].opcodes[0] = {type: 1, children: [1,2,3,4]};// ALT
-  this.rules[29].opcodes[1] = {type: 6, string: [32]};// TBS
-  this.rules[29].opcodes[2] = {type: 6, string: [9]};// TBS
-  this.rules[29].opcodes[3] = {type: 6, string: [10]};// TBS
-  this.rules[29].opcodes[4] = {type: 6, string: [13]};// TBS
+  this.rules[33].opcodes = [];
+  this.rules[33].opcodes[0] = {type: 1, children: [1,2,3,4]};// ALT
+  this.rules[33].opcodes[1] = {type: 6, string: [32]};// TBS
+  this.rules[33].opcodes[2] = {type: 6, string: [9]};// TBS
+  this.rules[33].opcodes[3] = {type: 6, string: [10]};// TBS
+  this.rules[33].opcodes[4] = {type: 6, string: [13]};// TBS
 
   /* sep */
-  this.rules[30].opcodes = [];
-  this.rules[30].opcodes[0] = {type: 2, children: [1,3,6]};// CAT
-  this.rules[30].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[30].opcodes[2] = {type: 4, index: 29};// RNM(ws)
-  this.rules[30].opcodes[3] = {type: 1, children: [4,5]};// ALT
-  this.rules[30].opcodes[4] = {type: 7, string: [59]};// TLS
-  this.rules[30].opcodes[5] = {type: 6, string: [10]};// TBS
-  this.rules[30].opcodes[6] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[30].opcodes[7] = {type: 4, index: 29};// RNM(ws)
+  this.rules[34].opcodes = [];
+  this.rules[34].opcodes[0] = {type: 2, children: [1,3,6]};// CAT
+  this.rules[34].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[34].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[34].opcodes[3] = {type: 1, children: [4,5]};// ALT
+  this.rules[34].opcodes[4] = {type: 7, string: [59]};// TLS
+  this.rules[34].opcodes[5] = {type: 6, string: [10]};// TBS
+  this.rules[34].opcodes[6] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[34].opcodes[7] = {type: 4, index: 33};// RNM(ws)
 
   /* begin-properties */
-  this.rules[31].opcodes = [];
-  this.rules[31].opcodes[0] = {type: 2, children: [1,3,4]};// CAT
-  this.rules[31].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[31].opcodes[2] = {type: 4, index: 29};// RNM(ws)
-  this.rules[31].opcodes[3] = {type: 7, string: [123]};// TLS
-  this.rules[31].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[31].opcodes[5] = {type: 4, index: 29};// RNM(ws)
+  this.rules[35].opcodes = [];
+  this.rules[35].opcodes[0] = {type: 2, children: [1,3,4]};// CAT
+  this.rules[35].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[35].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[35].opcodes[3] = {type: 7, string: [123]};// TLS
+  this.rules[35].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[35].opcodes[5] = {type: 4, index: 33};// RNM(ws)
 
   /* end-properties */
-  this.rules[32].opcodes = [];
-  this.rules[32].opcodes[0] = {type: 2, children: [1,3,4]};// CAT
-  this.rules[32].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[32].opcodes[2] = {type: 4, index: 29};// RNM(ws)
-  this.rules[32].opcodes[3] = {type: 7, string: [125]};// TLS
-  this.rules[32].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
-  this.rules[32].opcodes[5] = {type: 4, index: 29};// RNM(ws)
+  this.rules[36].opcodes = [];
+  this.rules[36].opcodes[0] = {type: 2, children: [1,3,4]};// CAT
+  this.rules[36].opcodes[1] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[36].opcodes[2] = {type: 4, index: 33};// RNM(ws)
+  this.rules[36].opcodes[3] = {type: 7, string: [125]};// TLS
+  this.rules[36].opcodes[4] = {type: 3, min: 0, max: Infinity};// REP
+  this.rules[36].opcodes[5] = {type: 4, index: 33};// RNM(ws)
 
   /* ALPHA */
-  this.rules[33].opcodes = [];
-  this.rules[33].opcodes[0] = {type: 1, children: [1,2]};// ALT
-  this.rules[33].opcodes[1] = {type: 5, min: 65, max: 90};// TRG
-  this.rules[33].opcodes[2] = {type: 5, min: 97, max: 122};// TRG
+  this.rules[37].opcodes = [];
+  this.rules[37].opcodes[0] = {type: 1, children: [1,2]};// ALT
+  this.rules[37].opcodes[1] = {type: 5, min: 65, max: 90};// TRG
+  this.rules[37].opcodes[2] = {type: 5, min: 97, max: 122};// TRG
 
   /* DIGIT */
-  this.rules[34].opcodes = [];
-  this.rules[34].opcodes[0] = {type: 5, min: 48, max: 57};// TRG
+  this.rules[38].opcodes = [];
+  this.rules[38].opcodes[0] = {type: 5, min: 48, max: 57};// TRG
 
   /* HEXDIG */
-  this.rules[35].opcodes = [];
-  this.rules[35].opcodes[0] = {type: 1, children: [1,2,3,4,5,6,7]};// ALT
-  this.rules[35].opcodes[1] = {type: 4, index: 34};// RNM(DIGIT)
-  this.rules[35].opcodes[2] = {type: 7, string: [97]};// TLS
-  this.rules[35].opcodes[3] = {type: 7, string: [98]};// TLS
-  this.rules[35].opcodes[4] = {type: 7, string: [99]};// TLS
-  this.rules[35].opcodes[5] = {type: 7, string: [100]};// TLS
-  this.rules[35].opcodes[6] = {type: 7, string: [101]};// TLS
-  this.rules[35].opcodes[7] = {type: 7, string: [102]};// TLS
+  this.rules[39].opcodes = [];
+  this.rules[39].opcodes[0] = {type: 1, children: [1,2,3,4,5,6,7]};// ALT
+  this.rules[39].opcodes[1] = {type: 4, index: 38};// RNM(DIGIT)
+  this.rules[39].opcodes[2] = {type: 7, string: [97]};// TLS
+  this.rules[39].opcodes[3] = {type: 7, string: [98]};// TLS
+  this.rules[39].opcodes[4] = {type: 7, string: [99]};// TLS
+  this.rules[39].opcodes[5] = {type: 7, string: [100]};// TLS
+  this.rules[39].opcodes[6] = {type: 7, string: [101]};// TLS
+  this.rules[39].opcodes[7] = {type: 7, string: [102]};// TLS
 
   // The `toString()` function will display the original grammar file(s) that produced these opcodes.
   this.toString = function(){
     var str = "";
-    str += "; A chunks document is composed of a series of statements that are\n";
-    str += "; either chunks, compact notations for rules or links, or comments.\n";
-    str += "; Spaces can be inserted about anywhere, but are only mandatory to separate\n";
-    str += "; tokens. In particular, spaces between statements are not mandatory, except\n";
-    str += "; after a compact link statement.\n";
-    str += "chunksDoc = *ws [statements] *ws\n";
-    str += "statements = *ws (\n";
-    str += "  comment [%x0A statements] /\n";
-    str += "  chunk [statements] /\n";
-    str += "  compact-rule [statements] /\n";
-    str += "  compact-link [ws statements])\n";
-    str += "\n";
-    str += "; Comments start with \"#\" and last until the end of the line or file\n";
-    str += "comment = \"#\" *char\n";
-    str += "\n";
-    str += "; A chunk has a type, an optional ID and a set of properties.\n";
-    str += "; The set of properties may be empty.\n";
-    str += "chunk = type [ws id] begin-properties [properties] end-properties\n";
-    str += "\n";
-    str += "; Compact rules associate a condition chunk with action chunks\n";
-    str += "compact-rule = chunk \"=>\" chunk *(\",\" chunk)\n";
-    str += "\n";
-    str += "; Compact links (subject predicate object)\n";
-    str += "compact-link = id ws property-name ws id\n";
-    str += "\n";
-    str += "; Chunk type\n";
-    str += "type = *ws (\"*\" / name)\n";
-    str += "\n";
-    str += "; Chunk IDs are regular names\n";
-    str += "id = name\n";
-    str += "\n";
-    str += "; Chunk properties\n";
-    str += "properties = property *(sep property)\n";
-    str += "property = property-name ws property-value\n";
-    str += "property-name = name\n";
-    str += "property-value = value *(\",\" value)\n";
-    str += "\n";
-    str += "; Property values\n";
-    str += "value = *ws (\"false\" / \"true\" / name / number / string) *ws\n";
-    str += "\n";
-    str += "; Names\n";
-    str += "name = *ws [\"@\"] 1*(ALPHA / DIGIT / \".\" / \"_\" / \"-\" / \"/\" / \":\") *ws\n";
-    str += "\n";
-    str += "; Numbers (same as in JSON)\n";
-    str += "number = [ minus ] int [ frac ] [ exp ]\n";
-    str += "decimal-point = \".\"\n";
-    str += "digit1-9 = %x31-39\n";
-    str += "e = %x65 / %x45\n";
-    str += "exp = e [ minus / plus ] 1*DIGIT\n";
-    str += "frac = decimal-point 1*DIGIT\n";
-    str += "int = zero / ( digit1-9 *DIGIT )\n";
-    str += "minus = \"-\"\n";
-    str += "plus = \"+\"\n";
-    str += "zero = \"0\"\n";
-    str += "\n";
-    str += "; Strings (same as in JSON)\n";
-    str += "string = quotation-mark *char quotation-mark\n";
-    str += "char = unescaped / escape (\n";
-    str += "  %x22 /          ; \"    quotation mark\n";
-    str += "  %x5C /          ; \\    reverse solidus\n";
-    str += "  %x2F /          ; /    solidus\n";
-    str += "  %x62 /          ; b    backspace\n";
-    str += "  %x66 /          ; f    form feed\n";
-    str += "  %x6E /          ; n    line feed\n";
-    str += "  %x72 /          ; r    carriage return\n";
-    str += "  %x74 /          ; t    tab\n";
-    str += "  %x75 4HEXDIG )  ; uXXXX\n";
-    str += "escape = %x5C\n";
-    str += "quotation-mark = %x22      ; \"\n";
-    str += "unescaped = %x20-21 / %x23-5B / %x5D-10FFFF\n";
-    str += "\n";
-    str += "; White space characters:\n";
-    str += "; space, horizontal tab, line feed, carriage return\n";
-    str += "ws = %x20 / %x09 / %x0A / %x0D\n";
-    str += "\n";
-    str += "; Semi-colon or new line to separate chunk properties\n";
-    str += "sep = *ws (\";\" / %x0A) *ws\n";
-    str += "\n";
-    str += "; Curly braces to enclose chunk properties\n";
-    str += "begin-properties = *ws \"{\" *ws\n";
-    str += "end-properties = *ws \"}\" *ws\n";
-    str += "\n";
-    str += "; Core definitions from the original RFC\n";
-    str += "ALPHA = %x41-5A / %x61-7A   ; A-Z / a-z\n";
-    str += "DIGIT = %x30-39             ; 0-9\n";
+    str += "; A chunks document is composed of a series of statements that are\r\n";
+    str += "; either chunks, compact notations for rules or links, or comments.\r\n";
+    str += "; Spaces can be inserted about anywhere, but are only mandatory to separate\r\n";
+    str += "; tokens. In particular, spaces between statements are not mandatory, except\r\n";
+    str += "; after a compact link statement.\r\n";
+    str += "chunksDoc = *ws [statements] *ws\r\n";
+    str += "statements = *ws (\r\n";
+    str += "  comment [%x0A statements] /\r\n";
+    str += "  chunk [statements] /\r\n";
+    str += "  compact-rule [statements] /\r\n";
+    str += "  compact-link [ws statements])\r\n";
+    str += "\r\n";
+    str += "; Comments start with \"#\" and last until the end of the line or file\r\n";
+    str += "comment = \"#\" *char\r\n";
+    str += "\r\n";
+    str += "; A chunk has a type, an optional ID and a set of properties.\r\n";
+    str += "; The set of properties may be empty.\r\n";
+    str += "chunk = type [ws id] begin-properties [properties] end-properties\r\n";
+    str += "\r\n";
+    str += "; Compact rules associate a condition chunk with action chunks\r\n";
+    str += "compact-rule = *\"!\" chunk \"=>\" chunk *(\",\" chunk)\r\n";
+    str += "\r\n";
+    str += "; Compact links (subject predicate object)\r\n";
+    str += "compact-link = id ws property-name ws id\r\n";
+    str += "\r\n";
+    str += "; Chunk type\r\n";
+    str += "type = *ws (\"*\" / name)\r\n";
+    str += "\r\n";
+    str += "; Chunk IDs are regular names\r\n";
+    str += "id = name\r\n";
+    str += "\r\n";
+    str += "; Chunk properties\r\n";
+    str += "properties = property *(sep property)\r\n";
+    str += "property = property-name ws property-value\r\n";
+    str += "property-name = name / reserved-name\r\n";
+    str += "property-value = value *(\",\" value)\r\n";
+    str += "\r\n";
+    str += "; Names\r\n";
+    str += "name = *ws inner-name *ws\r\n";
+    str += "reserved-name = *ws \"@\" inner-name *ws\r\n";
+    str += "negated = \"!\" *(inner-name / variable)\r\n";
+    str += "variable = \"?\" inner-name\r\n";
+    str += "inner-name = 1*(ALPHA / DIGIT / \".\" / \"_\" / \"-\" / \"/\" / \":\")\r\n";
+    str += "\r\n";
+    str += "; Property values\r\n";
+    str += "value = *ws (\"*\" / \"false\" / \"true\" / inner-name / variable / negated / number / string) *ws\r\n";
+    str += "\r\n";
+    str += "; Numbers (same as in JSON)\r\n";
+    str += "number = [ minus ] int [ frac ] [ exp ]\r\n";
+    str += "decimal-point = \".\"\r\n";
+    str += "digit1-9 = %x31-39\r\n";
+    str += "e = %x65 / %x45\r\n";
+    str += "exp = e [ minus / plus ] 1*DIGIT\r\n";
+    str += "frac = decimal-point 1*DIGIT\r\n";
+    str += "int = zero / ( digit1-9 *DIGIT )\r\n";
+    str += "minus = \"-\"\r\n";
+    str += "plus = \"+\"\r\n";
+    str += "zero = \"0\"\r\n";
+    str += "\r\n";
+    str += "; Strings (same as in JSON)\r\n";
+    str += "string = quotation-mark *char quotation-mark\r\n";
+    str += "char = unescaped / escape (\r\n";
+    str += "  %x22 /          ; \"    quotation mark\r\n";
+    str += "  %x5C /          ; \\    reverse solidus\r\n";
+    str += "  %x2F /          ; /    solidus\r\n";
+    str += "  %x62 /          ; b    backspace\r\n";
+    str += "  %x66 /          ; f    form feed\r\n";
+    str += "  %x6E /          ; n    line feed\r\n";
+    str += "  %x72 /          ; r    carriage return\r\n";
+    str += "  %x74 /          ; t    tab\r\n";
+    str += "  %x75 4HEXDIG )  ; uXXXX\r\n";
+    str += "escape = %x5C\r\n";
+    str += "quotation-mark = %x22      ; \"\r\n";
+    str += "unescaped = %x20-21 / %x23-5B / %x5D-10FFFF\r\n";
+    str += "\r\n";
+    str += "; White space characters:\r\n";
+    str += "; space, horizontal tab, line feed, carriage return\r\n";
+    str += "ws = %x20 / %x09 / %x0A / %x0D\r\n";
+    str += "\r\n";
+    str += "; Semi-colon or new line to separate chunk properties\r\n";
+    str += "sep = *ws (\";\" / %x0A) *ws\r\n";
+    str += "\r\n";
+    str += "; Curly braces to enclose chunk properties\r\n";
+    str += "begin-properties = *ws \"{\" *ws\r\n";
+    str += "end-properties = *ws \"}\" *ws\r\n";
+    str += "\r\n";
+    str += "; Core definitions from the original RFC\r\n";
+    str += "ALPHA = %x41-5A / %x61-7A   ; A-Z / a-z\r\n";
+    str += "DIGIT = %x30-39             ; 0-9\r\n";
     str += "HEXDIG = DIGIT / \"A\" / \"B\" / \"C\" / \"D\" / \"E\" / \"F\"\n";
     return str;
   }

--- a/grammar/chunks.abnf
+++ b/grammar/chunks.abnf
@@ -18,7 +18,7 @@ comment = "#" *char
 chunk = type [ws id] begin-properties [properties] end-properties
 
 ; Compact rules associate a condition chunk with action chunks
-compact-rule = chunk "=>" chunk *("," chunk)
+compact-rule = *"!" chunk "=>" chunk *("," chunk)
 
 ; Compact links (subject predicate object)
 compact-link = id ws property-name ws id
@@ -32,14 +32,18 @@ id = name
 ; Chunk properties
 properties = property *(sep property)
 property = property-name ws property-value
-property-name = name
+property-name = name / reserved-name
 property-value = value *("," value)
 
-; Property values
-value = *ws ("false" / "true" / name / number / string) *ws
-
 ; Names
-name = *ws ["@"] 1*(ALPHA / DIGIT / "." / "_" / "-" / "/" / ":") *ws
+name = *ws inner-name *ws
+reserved-name = *ws "@" inner-name *ws
+negated = "!" *(inner-name / variable)
+variable = "?" inner-name
+inner-name = 1*(ALPHA / DIGIT / "." / "_" / "-" / "/" / ":")
+
+; Property values
+value = *ws ("*" / "false" / "true" / inner-name / variable / negated / number / string) *ws
 
 ; Numbers (same as in JSON)
 number = [ minus ] int [ frac ] [ exp ]

--- a/grammar/rr.html
+++ b/grammar/rr.html
@@ -206,7 +206,7 @@
          <polygon points="669 17 661 13 661 21"/></svg></dd>
 
 <dt id="rr-compact-rule">compact-rule</dt>
-<dd class="railroad"><svg width="291" height="81">
+<dd class="railroad"><svg width="441" height="81">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -237,20 +237,23 @@
   </style>
          </defs>
          <polygon points="9 61 1 57 1 65"/>
-         <polygon points="17 61 9 57 9 65"/><a href="#rr-chunk" title="chunk">
-            <rect x="31" y="47" width="56" height="32"/>
-            <rect x="29" y="45" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="39" y="65">chunk</text></a><rect x="107" y="47" width="40" height="32" rx="10"/>
-         <rect x="105" y="45" width="40" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="115" y="65">=&gt;</text><a href="#rr-chunk" title="chunk">
-            <rect x="187" y="47" width="56" height="32"/>
-            <rect x="185" y="45" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="195" y="65">chunk</text></a><rect x="187" y="3" width="24" height="32" rx="10"/>
-         <rect x="185" y="1" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="195" y="21">,</text>
-         <path class="line" d="m17 61 h2 m0 0 h10 m56 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m23 44 h-3"/>
-         <polygon points="281 61 289 57 289 65"/>
-         <polygon points="281 61 273 57 273 65"/></svg></dd>
+         <polygon points="17 61 9 57 9 65"/>
+         <polygon points="51 29 58 13 134 13 141 29 134 45 58 45"/>
+         <polygon points="49 27 56 11 132 11 139 27 132 43 56 43" class="regexp"/>
+         <text class="regexp" x="64" y="31">[#x0021]</text><a href="#rr-chunk" title="chunk">
+            <rect x="181" y="47" width="56" height="32"/>
+            <rect x="179" y="45" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="189" y="65">chunk</text></a><rect x="257" y="47" width="40" height="32" rx="10"/>
+         <rect x="255" y="45" width="40" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="265" y="65">=&gt;</text><a href="#rr-chunk" title="chunk">
+            <rect x="337" y="47" width="56" height="32"/>
+            <rect x="335" y="45" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="345" y="65">chunk</text></a><rect x="337" y="3" width="24" height="32" rx="10"/>
+         <rect x="335" y="1" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="345" y="21">,</text>
+         <path class="line" d="m17 61 h2 m20 0 h10 m0 0 h100 m-130 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m110 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-110 0 h10 m90 0 h10 m20 34 h10 m56 0 h10 m0 0 h10 m40 0 h10 m20 0 h10 m56 0 h10 m-96 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m76 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-76 0 h10 m24 0 h10 m0 0 h32 m23 44 h-3"/>
+         <polygon points="431 61 439 57 439 65"/>
+         <polygon points="431 61 423 57 423 65"/></svg></dd>
 
 <dt id="rr-compact-link">compact-link</dt>
 <dd class="railroad"><svg width="385" height="37">
@@ -474,7 +477,7 @@
          <polygon points="353 17 345 13 345 21"/></svg></dd>
 
 <dt id="rr-property-name">property-name</dt>
-<dd class="railroad"><svg width="115" height="37">
+<dd class="railroad"><svg width="215" height="81">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -506,11 +509,14 @@
          </defs>
          <polygon points="9 17 1 13 1 21"/>
          <polygon points="17 17 9 13 9 21"/><a href="#rr-name" title="name">
-            <rect x="31" y="3" width="56" height="32"/>
-            <rect x="29" y="1" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="39" y="21">name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m56 0 h10 m3 0 h-3"/>
-         <polygon points="105 17 113 13 113 21"/>
-         <polygon points="105 17 97 13 97 21"/></svg></dd>
+            <rect x="51" y="3" width="56" height="32"/>
+            <rect x="49" y="1" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="59" y="21">name</text></a><a href="#rr-reserved-name" title="reserved-name">
+            <rect x="51" y="47" width="116" height="32"/>
+            <rect x="49" y="45" width="116" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="59" y="65">reserved-name</text></a><path class="line" d="m17 17 h2 m20 0 h10 m56 0 h10 m0 0 h60 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v24 m156 0 v-24 m-156 24 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m116 0 h10 m23 -44 h-3"/>
+         <polygon points="205 17 213 13 213 21"/>
+         <polygon points="205 17 197 13 197 21"/></svg></dd>
 
 <dt id="rr-property-value">property-value</dt>
 <dd class="railroad"><svg width="153" height="81">
@@ -554,64 +560,8 @@
          <polygon points="143 61 151 57 151 65"/>
          <polygon points="143 61 135 57 135 65"/></svg></dd>
 
-<dt id="rr-value">value</dt>
-<dd class="railroad"><svg width="359" height="247">
-         <defs>
-            <style type="text/css">
-    @namespace "http://www.w3.org/2000/svg";
-    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
-    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
-    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
-    .filled               {fill: #332900; stroke: none;}
-    text.terminal         {font-family: Verdana, Sans-serif;
-                            font-size: 12px;
-                            fill: #141000;
-                            font-weight: bold;
-                          }
-    text.nonterminal      {font-family: Verdana, Sans-serif;
-                            font-size: 12px;
-                            fill: #1A1400;
-                            font-weight: normal;
-                          }
-    text.regexp           {font-family: Verdana, Sans-serif;
-                            font-size: 12px;
-                            fill: #1F1800;
-                            font-weight: normal;
-                          }
-    rect, circle, polygon {fill: #332900; stroke: #332900;}
-    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
-    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
-    rect.text             {fill: none; stroke: none;}
-    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
-  </style>
-         </defs>
-         <polygon points="9 51 1 47 1 55"/>
-         <polygon points="17 51 9 47 9 55"/><a href="#rr-ws" title="ws">
-            <rect x="51" y="3" width="36" height="32"/>
-            <rect x="49" y="1" width="36" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="59" y="21">ws</text></a><rect x="147" y="37" width="52" height="32" rx="10"/>
-         <rect x="145" y="35" width="52" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="155" y="55">false</text>
-         <rect x="147" y="81" width="48" height="32" rx="10"/>
-         <rect x="145" y="79" width="48" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="155" y="99">true</text><a href="#rr-name" title="name">
-            <rect x="147" y="125" width="56" height="32"/>
-            <rect x="145" y="123" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="155" y="143">name</text></a><a href="#rr-number" title="number">
-            <rect x="147" y="169" width="68" height="32"/>
-            <rect x="145" y="167" width="68" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="155" y="187">number</text></a><a href="#rr-string" title="string">
-            <rect x="147" y="213" width="56" height="32"/>
-            <rect x="145" y="211" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="155" y="231">string</text></a><a href="#rr-ws" title="ws">
-            <rect x="275" y="3" width="36" height="32"/>
-            <rect x="273" y="1" width="36" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="283" y="21">ws</text></a><path class="line" d="m17 51 h2 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m40 34 h10 m52 0 h10 m0 0 h16 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m48 0 h10 m0 0 h20 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m56 0 h10 m0 0 h12 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m56 0 h10 m0 0 h12 m40 -176 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m23 34 h-3"/>
-         <polygon points="349 51 357 47 357 55"/>
-         <polygon points="349 51 341 47 341 55"/></svg></dd>
-
 <dt id="rr-name">name</dt>
-<dd class="railroad"><svg width="483" height="335">
+<dd class="railroad"><svg width="343" height="71">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -645,34 +595,271 @@
          <polygon points="17 51 9 47 9 55"/><a href="#rr-ws" title="ws">
             <rect x="51" y="3" width="36" height="32"/>
             <rect x="49" y="1" width="36" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="59" y="21">ws</text></a><rect x="147" y="69" width="32" height="32" rx="10"/>
-         <rect x="145" y="67" width="32" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="155" y="87">@</text><a href="#rr-ALPHA" title="ALPHA">
-            <rect x="259" y="37" width="60" height="32"/>
-            <rect x="257" y="35" width="60" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="267" y="55">ALPHA</text></a><a href="#rr-DIGIT" title="DIGIT">
-            <rect x="259" y="81" width="56" height="32"/>
-            <rect x="257" y="79" width="56" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="267" y="99">DIGIT</text></a><rect x="259" y="125" width="24" height="32" rx="10"/>
-         <rect x="257" y="123" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="267" y="143">.</text>
-         <rect x="259" y="169" width="28" height="32" rx="10"/>
-         <rect x="257" y="167" width="28" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="267" y="187">_</text>
-         <rect x="259" y="213" width="26" height="32" rx="10"/>
-         <rect x="257" y="211" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="267" y="231">-</text>
-         <rect x="259" y="257" width="28" height="32" rx="10"/>
-         <rect x="257" y="255" width="28" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="267" y="275">/</text>
-         <rect x="259" y="301" width="24" height="32" rx="10"/>
-         <rect x="257" y="299" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="267" y="319">:</text><a href="#rr-ws" title="ws">
-            <rect x="399" y="3" width="36" height="32"/>
-            <rect x="397" y="1" width="36" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="407" y="21">ws</text></a><path class="line" d="m17 51 h2 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m40 34 h10 m0 0 h42 m-72 0 h20 m52 0 h20 m-92 0 q10 0 10 10 m72 0 q0 -10 10 -10 m-82 10 v12 m72 0 v-12 m-72 12 q0 10 10 10 m52 0 q10 0 10 -10 m-62 10 h10 m32 0 h10 m60 -32 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m56 0 h10 m0 0 h4 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m24 0 h10 m0 0 h36 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m28 0 h10 m0 0 h32 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m26 0 h10 m0 0 h34 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m28 0 h10 m0 0 h32 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m24 0 h10 m0 0 h36 m-120 -264 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m120 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-120 0 h10 m0 0 h110 m40 32 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m23 34 h-3"/>
-         <polygon points="473 51 481 47 481 55"/>
-         <polygon points="473 51 465 47 465 55"/></svg></dd>
+            <text class="nonterminal" x="59" y="21">ws</text></a><a href="#rr-inner-name" title="inner-name">
+            <rect x="127" y="37" width="92" height="32"/>
+            <rect x="125" y="35" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="135" y="55">inner-name</text></a><a href="#rr-ws" title="ws">
+            <rect x="259" y="3" width="36" height="32"/>
+            <rect x="257" y="1" width="36" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="267" y="21">ws</text></a><path class="line" d="m17 51 h2 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m20 34 h10 m92 0 h10 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m23 34 h-3"/>
+         <polygon points="333 51 341 47 341 55"/>
+         <polygon points="333 51 325 47 325 55"/></svg></dd>
+
+<dt id="rr-reserved-name">reserved-name</dt>
+<dd class="railroad"><svg width="395" height="71">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"/>
+         <polygon points="17 51 9 47 9 55"/><a href="#rr-ws" title="ws">
+            <rect x="51" y="3" width="36" height="32"/>
+            <rect x="49" y="1" width="36" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="59" y="21">ws</text></a><rect x="127" y="37" width="32" height="32" rx="10"/>
+         <rect x="125" y="35" width="32" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="135" y="55">@</text><a href="#rr-inner-name" title="inner-name">
+            <rect x="179" y="37" width="92" height="32"/>
+            <rect x="177" y="35" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="187" y="55">inner-name</text></a><a href="#rr-ws" title="ws">
+            <rect x="311" y="3" width="36" height="32"/>
+            <rect x="309" y="1" width="36" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="319" y="21">ws</text></a><path class="line" d="m17 51 h2 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m20 34 h10 m32 0 h10 m0 0 h10 m92 0 h10 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m23 34 h-3"/>
+         <polygon points="385 51 393 47 393 55"/>
+         <polygon points="385 51 377 47 377 55"/></svg></dd>
+
+<dt id="rr-negated">negated</dt>
+<dd class="railroad"><svg width="301" height="115">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 95 1 91 1 99"/>
+         <polygon points="17 95 9 91 9 99"/>
+         <polygon points="31 97 38 81 114 81 121 97 114 113 38 113"/>
+         <polygon points="29 95 36 79 112 79 119 95 112 111 36 111" class="regexp"/>
+         <text class="regexp" x="44" y="99">[#x0021]</text><a href="#rr-inner-name" title="inner-name">
+            <rect x="161" y="47" width="92" height="32"/>
+            <rect x="159" y="45" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="169" y="65">inner-name</text></a><a href="#rr-variable" title="variable">
+            <rect x="161" y="3" width="70" height="32"/>
+            <rect x="159" y="1" width="70" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="169" y="21">variable</text></a><path class="line" d="m17 95 h2 m0 0 h10 m90 0 h10 m20 0 h10 m0 0 h102 m-132 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m112 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-112 0 h10 m92 0 h10 m-122 10 l0 -44 q0 -10 10 -10 m122 54 l0 -44 q0 -10 -10 -10 m-112 0 h10 m70 0 h10 m0 0 h22 m23 78 h-3"/>
+         <polygon points="291 95 299 91 299 99"/>
+         <polygon points="291 95 283 91 283 99"/></svg></dd>
+
+<dt id="rr-variable">variable</dt>
+<dd class="railroad"><svg width="197" height="37">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 17 1 13 1 21"/>
+         <polygon points="17 17 9 13 9 21"/>
+         <rect x="31" y="3" width="26" height="32" rx="10"/>
+         <rect x="29" y="1" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="39" y="21">?</text><a href="#rr-inner-name" title="inner-name">
+            <rect x="77" y="3" width="92" height="32"/>
+            <rect x="75" y="1" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="85" y="21">inner-name</text></a><path class="line" d="m17 17 h2 m0 0 h10 m26 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"/>
+         <polygon points="187 17 195 13 195 21"/>
+         <polygon points="187 17 179 13 179 21"/></svg></dd>
+
+<dt id="rr-inner-name">inner-name</dt>
+<dd class="railroad"><svg width="199" height="317">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 33 1 29 1 37"/>
+         <polygon points="17 33 9 29 9 37"/><a href="#rr-ALPHA" title="ALPHA">
+            <rect x="71" y="19" width="60" height="32"/>
+            <rect x="69" y="17" width="60" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="79" y="37">ALPHA</text></a><a href="#rr-DIGIT" title="DIGIT">
+            <rect x="71" y="63" width="56" height="32"/>
+            <rect x="69" y="61" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="79" y="81">DIGIT</text></a><rect x="71" y="107" width="24" height="32" rx="10"/>
+         <rect x="69" y="105" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="79" y="125">.</text>
+         <rect x="71" y="151" width="28" height="32" rx="10"/>
+         <rect x="69" y="149" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="79" y="169">_</text>
+         <rect x="71" y="195" width="26" height="32" rx="10"/>
+         <rect x="69" y="193" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="79" y="213">-</text>
+         <rect x="71" y="239" width="28" height="32" rx="10"/>
+         <rect x="69" y="237" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="79" y="257">/</text>
+         <rect x="71" y="283" width="24" height="32" rx="10"/>
+         <rect x="69" y="281" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="79" y="301">:</text>
+         <path class="line" d="m17 33 h2 m40 0 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m56 0 h10 m0 0 h4 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m24 0 h10 m0 0 h36 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m28 0 h10 m0 0 h32 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m26 0 h10 m0 0 h34 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m28 0 h10 m0 0 h32 m-90 -10 v20 m100 0 v-20 m-100 20 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m24 0 h10 m0 0 h36 m-120 -264 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m120 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-120 0 h10 m0 0 h110 m23 32 h-3"/>
+         <polygon points="189 33 197 29 197 37"/>
+         <polygon points="189 33 181 29 181 37"/></svg></dd>
+
+<dt id="rr-value">value</dt>
+<dd class="railroad"><svg width="383" height="379">
+         <defs>
+            <style type="text/css">
+    @namespace "http://www.w3.org/2000/svg";
+    .line                 {fill: none; stroke: #332900; stroke-width: 1;}
+    .bold-line            {stroke: #141000; shape-rendering: crispEdges; stroke-width: 2;}
+    .thin-line            {stroke: #1F1800; shape-rendering: crispEdges}
+    .filled               {fill: #332900; stroke: none;}
+    text.terminal         {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #141000;
+                            font-weight: bold;
+                          }
+    text.nonterminal      {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1A1400;
+                            font-weight: normal;
+                          }
+    text.regexp           {font-family: Verdana, Sans-serif;
+                            font-size: 12px;
+                            fill: #1F1800;
+                            font-weight: normal;
+                          }
+    rect, circle, polygon {fill: #332900; stroke: #332900;}
+    rect.terminal         {fill: #FFDB4D; stroke: #332900; stroke-width: 1;}
+    rect.nonterminal      {fill: #FFEC9E; stroke: #332900; stroke-width: 1;}
+    rect.text             {fill: none; stroke: none;}
+    polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
+  </style>
+         </defs>
+         <polygon points="9 51 1 47 1 55"/>
+         <polygon points="17 51 9 47 9 55"/><a href="#rr-ws" title="ws">
+            <rect x="51" y="3" width="36" height="32"/>
+            <rect x="49" y="1" width="36" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="59" y="21">ws</text></a><rect x="147" y="37" width="28" height="32" rx="10"/>
+         <rect x="145" y="35" width="28" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="155" y="55">*</text>
+         <rect x="147" y="81" width="52" height="32" rx="10"/>
+         <rect x="145" y="79" width="52" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="155" y="99">false</text>
+         <rect x="147" y="125" width="48" height="32" rx="10"/>
+         <rect x="145" y="123" width="48" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="155" y="143">true</text><a href="#rr-inner-name" title="inner-name">
+            <rect x="147" y="169" width="92" height="32"/>
+            <rect x="145" y="167" width="92" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="155" y="187">inner-name</text></a><a href="#rr-variable" title="variable">
+            <rect x="147" y="213" width="70" height="32"/>
+            <rect x="145" y="211" width="70" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="155" y="231">variable</text></a><a href="#rr-negated" title="negated">
+            <rect x="147" y="257" width="72" height="32"/>
+            <rect x="145" y="255" width="72" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="155" y="275">negated</text></a><a href="#rr-number" title="number">
+            <rect x="147" y="301" width="68" height="32"/>
+            <rect x="145" y="299" width="68" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="155" y="319">number</text></a><a href="#rr-string" title="string">
+            <rect x="147" y="345" width="56" height="32"/>
+            <rect x="145" y="343" width="56" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="155" y="363">string</text></a><a href="#rr-ws" title="ws">
+            <rect x="299" y="3" width="36" height="32"/>
+            <rect x="297" y="1" width="36" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="307" y="21">ws</text></a><path class="line" d="m17 51 h2 m20 0 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m40 34 h10 m28 0 h10 m0 0 h64 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m52 0 h10 m0 0 h40 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m48 0 h10 m0 0 h44 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m70 0 h10 m0 0 h22 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m72 0 h10 m0 0 h20 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m68 0 h10 m0 0 h24 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m56 0 h10 m0 0 h36 m40 -308 h10 m0 0 h46 m-76 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m56 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-56 0 h10 m36 0 h10 m23 34 h-3"/>
+         <polygon points="373 51 381 47 381 55"/>
+         <polygon points="373 51 365 47 365 55"/></svg></dd>
 
 <dt id="rr-number">number</dt>
 <dd class="railroad"><svg width="387" height="69">

--- a/index.html
+++ b/index.html
@@ -123,11 +123,23 @@
 
     <p>A <dfn>string literal</dfn> is an arbitrary set of characters. It is serialized enclosed in double quotes, following the same grammar as <a data-cite="RFC8259#section-7">strings in JSON</a> [[RFC8259]].</p>
 
-    <p>A <dfn>name</dfn> is a string that can include letters, digits, period, hyphen, underscore and slash characters, and that cannot be interpreted as a [=number=], a [=boolean=]. Additionally, a [=name=] may start with:</p>
+    <p>A <dfn>name</dfn> is a string that can include letters, digits, period, hyphen, underscore and slash characters, and that cannot be interpreted as a [=number=], a [=boolean=]. Additionally, depending on the context under which it is used, a [=name=] may start with one of the [[[#name-operators]]].</p>
+
+    <p>A property [=value=] |a| <dfn>equals</dfn> property [=value=] |b| when the following algorithm returns <code>true</code>:</p>
     <ul>
-      <li><code>@</code> to denote a <dfn>reserved name</dfn> with specific meaning (defined in this specification). Such [=names=] may only appear as [=property=] names.</li>
-      <li><code>?</code> to denote a [=variable=]. Such [=names=] may only appear as [=property=] values.</li>
-      <li><code>!</code> to [=negate=] a match. The <code>!</code> prefix may be followed by <code>?</code> to reference a [=variable=]. Also, the [=name=] may actually equal <code>!</code> to test that a [=property=] is undefined.</li>
+      <li>If |a| is the [=wild card operator=] <code>*</code>, return <code>true</code>.</li>
+      <li>If |b| is the [=wild card operator=] <code>*</code>, return <code>true</code>.</li>
+      <li>If |a| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
+      <li>If |b| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
+      <li>If |a| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if !|a| [=equals=] |b|, <code>true</code> otherwise.</li>
+      <li>If |b| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if |a| [=equals=] !|b|, <code>true</code> otherwise.</li>
+      <li>If |a| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
+      <li>If |b| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
+      <li>If |a| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |v| [=equals=] |b|, <code>false</code> otherwise.</li>
+      <li>If |b| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |a| [=equals=] |v|, <code>false</code> otherwise.</li>
+      <li>If |a| and |b| are identical [=atomic values=], return <code>true</code>.</li>
+      <li>If |a] and |b| are lists of [=atomic values=], both lists have the same length, and [=atomic values=] at the same position in |a| and |b| are [=equal=], return <code>true</code>.</li>
+      <li>Otherwise, return <code>false</code>.</li>
     </ul>
   </section>
 </section>
@@ -328,92 +340,288 @@ memory a2 { @module facts }</code></pre>
       </section>
 
       <section>
-        <h4>Variables</h4>
+        <h4>Matching chunks</h4>
 
-        <p>A <dfn>variable</dfn> is a [=name=] that starts with <code>?</code> that represents a symbolic name to a [=value=]. A [=variable=] gets <dfn>bound</dfn> to a [=value=] in [=conditions=]. The [=value=] can then be referenced in [=actions=] using the [=variable=]'s name. Effectively, [=variables=] allow applications to copy information from rule [=conditions=] to rule [=actions=].</p>
+        <p>A [=chunk=] |A| <dfn data-lt="matching chunk">matches</dfn> [=chunk=] |B| if the conditions below are all met:</p>
+        <ul>
+          <li><i>Context</i>. One of the following conditions holds true:
+            <ul>
+              <li>Neither |A| nor |B| have [=@context=] properties.</li>
+              <li>Both |A| and |B| have [=@context=] properties and |A|'s [=@context=] property [=value=] [=equals=] |B|'s [=@context=] property [=value=].</li>
+            </ul>
+          </li>
+          <li><i>Identifier</i>. One of the following conditions holds true:
+            <ul>
+              <li>|A| has an [=@id=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=identifier=].</li>
+              <li>|A| does not have an [=@id=] property.</li>
+            </ul>
+          </li>
+          <li><i>Inheritance</i>. One of the following conditions holds true:
+            <ul>
+              <li>|A| has an [=@kindof=] property whose [=value=] |V| is an [=atomic value=], and |B|'s [=type=] is a subclass of |V|, meaning that |B|'s [=type=] is |V| or there exists a chain of <code>kindof</code> links between |V| and |B|'s [=type=].</li>
+              <li>|A| does not have an [=@kindof=] property.</li>
+            </ul>
+          </li>
+          <li><i>Properties</i>. For each [=property=] |p| in |A| whose [=name=] does not start with <code>@</code>, either of the following holds true:
+            <ul>
+              <li>|p|'s [=value=] is <code>!</code> and there is no [=property=] in |B| with |p|'s [=name=].</li>
+              <li>|p|'s [=value=] is not <code>!</code> and there exits a [=property=] in |B| with the same [=name=] and [=equal=] [=value=] as |p|.</li>
+            </ul>
+          </li>
+          <li><i>Type</i>. One of the following conditions holds true:
+            <ul>
+              <li>|A| has an [=@type=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=type=].</li>
+              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] is <code>*</code>.</li>
+              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] and |B|'s [=type=] are identical.</li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+    </section>
 
-        <p>[=Variables=] are scoped to the [=rule=] where they appear.</p>
+    <section>
+      <h3>Modules</h3>
+      <p>A <dfn>module</dfn> is a [=graph of chunks=] associated with one and only one [=module buffer=]. A [=module=] has a <dfn>module name</dfn> that follows the [=name=] data type, and that is typically used to target the [=module=] in [=@module=] properties.</p>
 
-        <aside class="example" title="Variable binding and referencing">
-          <pre><code>count { state start; from ?num1; to ?num2 }
-  => increment { @module facts; @do get; number ?num1 }</code></pre>
-          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=]. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk, and the value of the [=variable=] <code>?num2</code> to the [=value=] of the <code>to</code> [=property=].</p>
-          <p>The [=rule=] defines an [=action=] that looks for a [=chunk=] in the <code>facts</code> [=module=] whose [=type=] is <code>increment</code> and that has a [=property=] named <code>number</code> and whose [=value=] equals the value of the <code>?num1</code> [=variable=].</p>
+      <p>A [=module=] supports [=built-in operations=], and may support additional operations defined by the application when the [=module=] is initialized.</p>
+      <p>A [=module=] represents a cognitive database on which the [=rule engine=] may operate. It may be viewed as a region in the cerebral cortex, where the [=module buffer=] corresponds to the bundle of nerve fibres connecting to that region.</p>
+
+      <p>The [=rule engine=] automatically creates a module named <code>goal</code>, which will therefore always exist in a rule execution context.</p>
+
+      <p>The [=@module=] property allows [=conditions=] and [=actions=] to reference the [=module name=] of the [=module=] they relate to. In the absence of an [=@module=] property, [=conditions=] and [=actions=] apply to the <code>goal</code> module.</p>
+
+      <section>
+        <h4>Module buffers</h4>
+        <p>A <dfn>module buffer</dfn> is a container for at most one [=chunk=]. The mammalian brain is richly connected locally, and weakly remotely. A [=module buffer=] mimics the constrained communication capacity of the mammalian brains for such long range communication.</p>
+
+        <p>The [=rule engine=] operates on a module's [=graph of chunks=] through its [=module buffer=].</p>
+
+        <p>A [=module buffer=] has a <dfn data-dfn-for="module buffer">status</dfn>, whose value is initially [=status/okay=], and which reflects the outcome of the last [=action=] held and performed by the [=module buffer=]. Values can be:</p>
+        <dl>
+          <dt><dfn><code>pending</code></dfn></dt>
+          <dd>The operation is still pending.</dd>
+          <dt><dfn><code>okay</code></dfn></dt>
+          <dd>The operation completed successfully.</dd>
+          <dd><p class="issue">Switch to <code>ok</code>? This seems more common in technologies (e.g. HTTP) than <code>okay</code>.</p></dd>
+          <dt><dfn><code>forbidden</code></dfn></dt>
+          <dd>The operation was not allowed.</dd>
+          <dt><dfn><code>nomatch</code></dfn></dt>
+          <dd>The operation failed because there was no [=matching chunk=] for the [=action=] in the targeted [=module=].</dd>
+          <dt><dfn><code>failed</code></dfn></dt>
+          <dd>The operation failed.</dd>
+        </dl>
+
+        <p>A [=module buffer=] has a <dfn>queue</dfn>, which is a set of [=chunks=], initially empty. Each chunk in the [=queue=] has a <dfn>priority</dfn>, represented by an integer from 1 to 10, with 10 the highest priority. The default [=priority=] is 5. [=Chunks=] are ordered by descending [=priority=] in a [=queue=]. When [=priorities=] match, [=chunks=] are ordered by insertion order (first in, first out).</p>
+
+        <p>The <dfn><code>@priority</code></dfn> property lets [=actions=] set the [=priority=] of a [=chunk=] when they add it to a [=queue=].</p>
+
+        <aside class="note" title="Queue and sub-goals">
+          <p>A [=queue=] may be useful to create sub-goals. For instance, whilst [=@do update=] operations allow applications to switch to a new goal, they may prefer [=rules=] to propose multiple sub-goals instead. [=Queues=] enable this through [=@do queue=] operations which push the [=chunk=] specified by an [=action=] to the [=queue=] of a [=module buffer=].</p>
         </aside>
 
-        <p>[=Variables=] are [=bound=] to a [=value=] the first time they appear in a [=condition=]. Subsequent occurrences of the same [=variable=] in a [=condition=] reference their [=value=].</p>
-
-        <aside class="example" title="Variable binding and referencing in the same condition">
-          <pre><code>count { state start; from ?num1; to ?num1 }
-  => console { @do log; message ?num1 }</code></pre>
-          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=] that have identical values. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk.</p>
-        </aside>
-
-        <p>[=Variables=] may represent any type of [=value=]. In particular, a [=variable=] that [=matches=] a property whose value is a list of [=atomic values=] gets bound to the list of [=atomic values=].</p>
-
-        <aside class="example" title="Variable binding to a list of atomic values">
-          <pre><code>basket { fruit ?f }
-  => console { @do log; message ?f }</code></pre>
-          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=]. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?f</code> to <code>apple, banana, orange</code>:</p>
-          <pre><code>basket { fruit apple, banana, orange }</code></pre>
-        </aside>
-
-        <p>A [=condition=] that contains a [=property=] with a list of [=variables=] [=matches=] a list of [=atomic values=] that has the same length. The [=condition=] does not [=match=] when the lengths of the lists differ.</p>
-
-        <aside class="example" title="Variable binding to atomic values in a list">
-          <pre><code>basket { fruit ?a, ?b, ?o }
-  => console { @do log; message ?a, ?b, ?o }</code></pre>
-          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=] whose value is a list of <em>three</em> atomic values. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?a</code> to <code>apple</code>, <code>?b</code> to <code>banana</code>, and <code>?o</code> to <code>orange</code>:</p>
-          <pre><code>basket { fruit apple, banana, orange }</code></pre>
-        </aside>
+        <p>A [=module buffer=] is automatically cleared when the [=actions=] associated with the [=rule=] it contained did not update the contents of targeted [=module buffers=]. This pops the [=queue=] if it is not already empty.</p>
       </section>
 
       <section>
-        <h4>The negation operator <code>!</code></h4>
-        <p>The <dfn data-lt="negative operation">negation operator</dfn> <code>!</code> may be prepended to [=names=] to <dfn>negate</dfn> the outcome of their evaluation. The [=negation operator=] may be used in one of the following cases:</p>
-        <ul>
-          <li>
-            In a [=rule=] in front of a [=condition=] to negate it. A rule with a negated [=condition=] !|cond| applies if and only if |cond| does not hold true.
-            <aside class="example" title="Negate a rule condition">
-              <pre><code># Rule with a negated condition
+        <h4>Built-in operations</h4>
+        <p>The [=@do=] property lets an [=action=] specify the graph algorithm or operation to execute. The default operation is to update the [=module buffer=], similar to calling [=@do update=].</p>
+
+        <p>All [=modules=] support the <dfn>built-in operations</dfn> defined in this section.</p>
+
+        <p>All [=modules=] also support the [=@for=] property to iterate over a set of items in a comma separated list. This has the effect of loading the [=module buffer=] with the first item in the list. The index range can optionally be specified with [=@from=] and [=@to=], where the first item in the list has index <code>0</code>.</p>
+
+        <aside class="note" title="Application-defined operations">
+          <p>Applications can define additional operations when initialising a [=module=]. This can be used to perform a variety of operations, e.g. to allow rules to command a robot to move its arm, by passing it the desired position and direction of the robot's hand. Operations can be defined to allow messages to be spoken aloud or to support complex graph algorithms, e.g. for data analytics and machine learning.</p>
+
+          <p>Applications cannot replace the [=built-in operations=].</p>
+        </aside>
+
+        <section>
+          <h5>The <dfn><code>@do clear</code></dfn> operation</h5>
+          <p>Clears the [=module buffer=] and pops the [=queue=].</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do delete</code></dfn> operation</h5>
+          <p>Forgets [=matching chunks=] in the [=graph of chunks=].</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do get</code></dfn> operation</h5>
+          <p>Looks for a [=matching chunk=] in the module's [=graph of chunks=] and puts a copy of it in the [=module buffer=] if found. Modifying the [=properties=] of a [=chunk=] copied from a [=graph of chunks=] (e.g. through a [=@do update=] operation) will not alter the underlying [=graph of chunks=]. To save an updated [=chunk=], a [=@do put=] or [=@do patch=] command needs to be issued.</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do next</code></dfn> operation</h5>
+          <p>Loads the next [=matching chunk=] to the targeted [=module buffer=] in an implementation dependent order.</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do patch</code></dfn> operation</h5>
+          <p>If the [=chunk=] in the targeted [=module buffer=] has the same [=identifier=] as a [=chunk=] in the underlying [=graph of chunks=], patches the [=chunk=] in the [=graph of chunks=] with the [=properties=] that appear in the [=module buffer=], excluding [=properties=] prefixed with an <code>@</code> character.</p>
+          <p class="issue">What is the expected behavior when the action has an <code>@id</code> property?</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do properties</code></dfn> operation</h5>
+          <p>Initiates an iteration over the [=properties=] of the [=matching chunk=] that do not begin with <code>@</code>. Each [=property=] is mapped to a new [=chunk=] with the same [=type=] as the [=action=]. The action's properties are copied over, and <code>name</code> and <code>value</code> properties are used to pass the [=property=] name and value respectively. The [=@more=] property is given the value <code>true</code> unless this is the final [=chunk=] in the iteration, in which case [=@more=] is given the value false. By default, the iteration is written to the same [=module buffer=] as designated by the [=action=] that initiated it. However, you can designate a different [=module buffer=] with the [=@to=] property. By setting additional properties in the initiating action, you can ensure that the rules used to process the property name and value are distinct from other such iterations.</p>
+          <aside class="example" title="Iterate over properties">
+            <p>The following example first sets the <code>facts</code> [=module buffer=] to a [=chunk=] of [=type=] <code>foo</code>, and then initiates an iteration over all of the [=chunk=]'s properties:</p>
+            <pre><code>run {}
+  =>
+    foo {@module facts; a 1; c 2}, # set facts buffer to foo {a 1; c 2}
+    bar {@module facts; @do properties; loop prop18; @to goal} # launch iteration
+
+# this rule is invoked with the name and value for each property
+# note that 'loop prop18' is copied over from the initiating chunk
+# (also note that "@do log" is an hypothetical operation to log a message)
+bar {loop prop18; name ?name; value ?value}
+  =>
+    console {@do log; message ?name, is, ?value},
+    bar {@do next}  # to load the next instance from the iteration</code></pre>
+          </aside>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do put</code></dfn> operation</h5>
+          <p>Saves the contents of the [=module buffer=] as a [=chunk=] to the module's [=graph of chunks=]. If the [=action=] has an [=@id=] property, this operation will overwrite the [=chunk=] with the same [=identifier=] or will create a new [=chunk=] with the given [=identifier=] if it does not exist already. This operation will also create a new [=chunk=] in the absence of an [=@id=] property.</p>
+          <p class="issue">If a chunk was loaded with <code>@do get</code>, then updated with <code>@do update</code>, would a call to <code>@do patch</code> create a new chunk if <code>@id</code> is not set? Or would it rather update the chunk in the graph?</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do queue</code></dfn> operation</h5>
+          <p>Pushes a [=chunk=] to the [=queue=] for the [=module buffer=]. If a [=@priority=] property is set to an integer value between 1 and 10, the [=priority=] of the [=chunk=] in the [=queue=] is set to that value.</p>
+        </section>
+
+        <section>
+          <h5>The <dfn><code>@do update</code></dfn> operation</h5>
+          <p>Directly updates the [=module buffer=] if the chunk [=type=] for the [=action=] is the same as the [=chunk=] currently held in the [=module buffer=]. The operation updates the properties given in the [=action=], leaving aside properties prefixed with an <code>@</code> character, and leaving other existing properties unchanged. If the chunk [=type=] for the action is not the same as the [=chunk=] currently held in the [=module buffer=], a new [=chunk=] is created with the properties given in the [=action=], excluding properties prefixed with an <code>@</code> character. This is the default action when an [=action=] has neither an [=@do=] property nor an [=@for=] property.</p>
+          <p class="issue">How can one update the properties prefixed with an <code>@</code> character in a [=chunk=] such as [=@context=], [=@subject=] or [=@object=]?</p>
+        </section>
+      </section>
+    </section>
+  </section>
+
+  <section>
+    <h2>Name operators</h2>
+    <p>Operators defined in this section may be used on their own as [=names=] or in front of [=names=] to alter their meaning.</p>
+
+    <section>
+      <h3>The variable operator <code>?</code></h3>
+
+      <p>The <dfn>variable operator</dfn> <code>?</code> may be prepended to a [=name=] when used as a [=property=] value to turn the [=name=] into a <dfn>variable</dfn> which represents a symbolic name to a [=value=]. A [=variable=] gets <dfn>bound</dfn> to a [=value=] in a [=condition=]. The [=value=] can then be referenced in [=actions=] using the [=variable=]'s name. Effectively, [=variables=] allow applications to copy information from rule [=conditions=] to rule [=actions=].</p>
+
+      <p>[=Variables=] are scoped to the [=rule=] where they appear.</p>
+
+      <aside class="example" title="Variable binding and referencing">
+        <pre><code>count { state start; from ?num1; to ?num2 }
+=> increment { @module facts; @do get; number ?num1 }</code></pre>
+        <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=]. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk, and the value of the [=variable=] <code>?num2</code> to the [=value=] of the <code>to</code> [=property=].</p>
+        <p>The [=rule=] defines an [=action=] that looks for a [=chunk=] in the <code>facts</code> [=module=] whose [=type=] is <code>increment</code> and that has a [=property=] named <code>number</code> and whose [=value=] equals the value of the <code>?num1</code> [=variable=].</p>
+      </aside>
+
+      <p>[=Variables=] are [=bound=] to a [=value=] the first time they appear in a [=condition=]. Subsequent occurrences of the same [=variable=] in a [=condition=] reference their [=value=].</p>
+
+      <aside class="example" title="Variable binding and referencing in the same condition">
+        <pre><code>count { state start; from ?num1; to ?num1 }
+=> console { @do log; message ?num1 }</code></pre>
+        <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=] that have identical values. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk.</p>
+      </aside>
+
+      <p>[=Variables=] may represent any type of [=value=]. In particular, a [=variable=] that [=matches=] a property whose value is a list of [=atomic values=] gets bound to the list of [=atomic values=].</p>
+
+      <aside class="example" title="Variable binding to a list of atomic values">
+        <pre><code>basket { fruit ?f }
+=> console { @do log; message ?f }</code></pre>
+        <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=]. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?f</code> to <code>apple, banana, orange</code>:</p>
+        <pre><code>basket { fruit apple, banana, orange }</code></pre>
+      </aside>
+
+      <p>A [=condition=] that contains a [=property=] with a list of [=variables=] [=matches=] a list of [=atomic values=] that has the same length. The [=condition=] does not [=match=] when the lengths of the lists differ.</p>
+
+      <aside class="example" title="Variable binding to atomic values in a list">
+        <pre><code>basket { fruit ?a, ?b, ?o }
+=> console { @do log; message ?a, ?b, ?o }</code></pre>
+        <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=] whose value is a list of <em>three</em> atomic values. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?a</code> to <code>apple</code>, <code>?b</code> to <code>banana</code>, and <code>?o</code> to <code>orange</code>:</p>
+        <pre><code>basket { fruit apple, banana, orange }</code></pre>
+      </aside>
+    </section>
+
+    <section>
+      <h3>The wild card operator <code>*</code></h3>
+      <p>The <dfn>wild card operator</dfn> <code>*</code> may be used on its own in lieu of a [=name=] in one of the following cases:</p>
+      <ul>
+        <li>
+          As the [=type=] of a [=condition=] or [=action=] to denote that [=condition=] or [=action=] matches a [=chunk=] regardless of its [=type=].
+          <aside class="example" title="Condition that matches any chunk">
+            <pre><code>* {} => ...</code></pre>
+            <p>The <code>* {}</code> [=condition=] [=matches=] a [=chunk=] regardless of its [=type=] and [=properties=].</p>
+          </aside>
+        </li>
+        <li>
+          In a [=condition=] as the [=value=] of a [=property=] |p| to have the [=condition=] [=match=] a [=chunk=] that has a [=property=] whose [=name=] equals |p|'s [=name=], regardless of its [=value=].
+          <aside class="example" title="Match a property regardless of its value">
+            <pre><code>basket { fruit * } => ...</code></pre>
+            <p>The [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which has a <code>fruit</code> [=property=] .</p>
+          </aside>
+          <p class="note">A [=variable=] may also be used to [=match=] on any [=value=]. The [=wild card operator=] avoids the need to provide a name for the [=variable=] when the actual [=value=] does not need to be captured.</p>
+        </li>
+        <li>
+          In a [=condition=] as an [=atomic value=] in a list to [=match=] any [=atomic value=] at the same position in a [=chunk=].
+          <aside class="example" title="Match an atomic value in a list">
+            <pre><code>basket { fruit apple, *, * } => ...</code></pre>
+            <p>The [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which has a <code>fruit</code> [=property=] whose [=value=] is a list of three [=atomic values=] starting with <code>apple</code>.</p>
+          </aside>
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h3>The negation operator <code>!</code></h3>
+      <p>The <dfn data-lt="negative operation">negation operator</dfn> <code>!</code> may be prepended to [=names=] to <dfn>negate</dfn> the outcome of their evaluation. The [=negation operator=] may be used in one of the following cases:</p>
+      <ul>
+        <li>
+          In a [=rule=] in front of a [=condition=] to negate it. A rule with a negated [=condition=] !|cond| applies if and only if |cond| does not hold true.
+          <aside class="example" title="Negate a rule condition">
+            <pre><code># Rule with a negated condition
 rule {
-  @condition !c1
-  @action a1
+@condition !c1
+@action a1
 }
 person c1 { @id John }
 console a1 { @do log; message "Type is not person or id is not John" }
 
 # Same rule defined using the compact format
 !person { @id John }
-  => console { @do log; message "Type is not person or id is not John" }</code></pre>
-              <p>The above example illustrates two equivalent ways to define a rule with a negated condition. In this example, the condition |c1| [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <code>John</code>. As such, the negated condition [=matches=] a [=chunk=] whose [=type=] is <em>not</em> <code>person</code> <em>or</em> whose [=identifier=] is <em>not</em> <code>John</code>.</p>
-            </aside>
-          </li>
-          <li>
-            In a [=condition=] in front of a [=property=] value to negate the result of a [=match=]. A negated [=property=] value !|val1| [=equals=] another [=property=] value |val2| if and only if |val1| does not [=equal=] |val2|.
-            <aside class="example" title="Negate a value match">
-              <pre><code>person { @id !John }
-  => console { @do log; message "Type is person but id is not John" }</code></pre>
-              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <em>not</em> <code>John</code>.</p>
-            </aside>
-            <aside class="example" title="Negate an atomic value in a list">
-              <pre><code>basket { fruit ?a, !banana, ?o }
-  => console { @do log; message "No banana in second position" }</code></pre>
-              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which has a <code>fruit</code> [=property=] whose [=value=] is a list of three [=atomic values=]. First and third [=atomic values=] in that list can be anything. Second [=atomic value=] must <em>not</em> be <code>banana</code>.</p>
-            </aside>
-          </li>
-          <li>
-            On its own as a [=property=] value in a [=condition=] to test that a [=property=] is undefined. A [=condition=] with a [=property=] |p| whose value is <code>!</code> [=matches=] a [=chunk=] if and only if the [=chunk=] does not have a [=property=] whose [=name=] is |p|'s [=name=].
-            <aside class="example" title="Test that a property is undefined">
-              <pre><code>basket { fruit ! }
-  => console { @do log; message "Basket without fruits" }</code></pre>
-              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which does not have a <code>fruit</code> [=property=].</p>
-            </aside>
-          </li>
-          <li>
-            On its own as a [=property=] value in a [=@do patch=], [=@do update=] or similar [=action=] that updates a [=chunk=] to unset a [=property=].
-            <aside class="example" title="Unset a chunk property">
-              <pre><code># Given the following chunk in the module buffer
+=> console { @do log; message "Type is not person or id is not John" }</code></pre>
+            <p>The above example illustrates two equivalent ways to define a rule with a negated condition. In this example, the condition |c1| [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <code>John</code>. As such, the negated condition [=matches=] a [=chunk=] whose [=type=] is <em>not</em> <code>person</code> <em>or</em> whose [=identifier=] is <em>not</em> <code>John</code>.</p>
+          </aside>
+        </li>
+        <li>
+          In a [=condition=] in front of a [=property=] value to negate the result of a [=match=]. A negated [=property=] value !|val1| [=equals=] another [=property=] value |val2| if and only if |val1| does not [=equal=] |val2|.
+          <aside class="example" title="Negate a value match">
+            <pre><code>person { @id !John }
+=> console { @do log; message "Type is person but id is not John" }</code></pre>
+            <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <em>not</em> <code>John</code>.</p>
+          </aside>
+          <aside class="example" title="Negate an atomic value in a list">
+            <pre><code>basket { fruit ?a, !banana, ?o }
+=> console { @do log; message "No banana in second position" }</code></pre>
+            <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which has a <code>fruit</code> [=property=] whose [=value=] is a list of three [=atomic values=]. First and third [=atomic values=] in that list can be anything. Second [=atomic value=] must <em>not</em> be <code>banana</code>.</p>
+          </aside>
+        </li>
+        <li>
+          On its own as a [=property=] value in a [=condition=] to test that a [=property=] is undefined. A [=condition=] with a [=property=] |p| whose value is <code>!</code> [=matches=] a [=chunk=] if and only if the [=chunk=] does not have a [=property=] whose [=name=] is |p|'s [=name=].
+          <aside class="example" title="Test that a property is undefined">
+            <pre><code>basket { fruit ! }
+=> console { @do log; message "Basket without fruits" }</code></pre>
+            <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which does not have a <code>fruit</code> [=property=].</p>
+          </aside>
+        </li>
+        <li>
+          On its own as a [=property=] value in a [=@do patch=], [=@do update=] or similar [=action=] that updates a [=chunk=] to unset a [=property=].
+          <aside class="example" title="Unset a chunk property">
+            <pre><code># Given the following chunk in the module buffer
 basket { fruit apple, banana, orange }
 
 # ... the following rule drops the fruit property
@@ -421,13 +629,13 @@ basket { fruit apple, banana, orange }
 
 # Resulting chunk
 basket {}</code></pre>
-            </aside>
-          </li>
-        </ul>
+          </aside>
+        </li>
+      </ul>
 
-        <p>The [=negation operator=] cannot be prepended to a [=variable=] that has not yet been [=bound=]. Similarly, the [=negation operator=] cannot be used on its own as an [=atomic value=] in a list. More generally, the [=negation operator=] cannot be used elsewhere than in the cases detailed above.</p>
-        <aside class="example" title="Some invalid uses of the negation operator">
-          <pre><code># Invalid: variable ?num1 is unbound
+      <p>The [=negation operator=] cannot be prepended to a [=variable=] that has not yet been [=bound=]. Similarly, the [=negation operator=] cannot be used on its own as an [=atomic value=] in a list. More generally, the [=negation operator=] cannot be used elsewhere than in the cases detailed above.</p>
+      <aside class="example" title="Some invalid uses of the negation operator">
+        <pre><code># Invalid: variable ?num1 is unbound
 count { state counting; start !?num1 } => ...
 
 # Invalid: on its own in a list
@@ -435,17 +643,22 @@ basket { fruit ?a, !, ?o } => ...
 
 # Invalid: in an update action but not on its own
 * {} => basket { @do update; fruit !apple }</code></pre>
-        </aside>
+      </aside>
 
-        <p>A second [=negation operator=] prepended to a [=name=] that starts with a [=negation operator=] cancels the effect of the first [=negation operator=].</p>
-        <aside class="example" title="Double negation">
-          <pre><code># The following condition
+      <p>A second [=negation operator=] prepended to a [=name=] that starts with a [=negation operator=] cancels the effect of the first [=negation operator=].</p>
+      <aside class="example" title="Double negation">
+        <pre><code># The following condition
 person { @id !!John }
 
 # ... is the same as this one:
 person { @id John }</code></pre>
-        </aside>
-      </section>
+      </aside>
+    </section>
+
+    <section>
+      <h3>The reserved name operator <code>@</code></h3>
+      <p>The <dfn>reserved name operator</dfn> <code>@</code> may be prepended to a [=name=] to denote a <dfn>reserved name</dfn> with specific meaning (defined in this specification). Such [=names=] may only appear as [=property=] names.</p>
+      <p>[=Reserved names=] control the behavior of [=conditions=] and [=actions=].</p>
 
       <section>
         <h4>@-properties for conditions and actions</h4>
@@ -583,182 +796,6 @@ digits { @shift 0, @to list }</code></pre>
         </section>
 
         <p class="ednote">TODO: Complete list with additional reserved names: <code>@undefined</code>, <code>@unique</code>, <code>@compile</code>, <code>@index</code>, <code>@map</code>, <code>@priority</code>, <code>@source</code>, <code>@tag</code>, <code>@uncompile</code>, <code>@undefine</code>.</p>
-      </section>
-
-      <section>
-        <h4>Matching chunks</h4>
-
-        <p>A property [=value=] |a| <dfn>equals</dfn> property [=value=] |b| when the following algorithm returns <code>true</code>:</p>
-        <ul>
-          <li>If |a| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
-          <li>If |b| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
-          <li>If |a| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if !|a| [=equals=] |b|, <code>true</code> otherwise.</li>
-          <li>If |b| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if |a| [=equals=] !|b|, <code>true</code> otherwise.</li>
-          <li>If |a| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
-          <li>If |b| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
-          <li>If |a| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |v| [=equals=] |b|, <code>false</code> otherwise.</li>
-          <li>If |b| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |a| [=equals=] |v|, <code>false</code> otherwise.</li>
-          <li>If |a| and |b| are identical [=atomic values=], return <code>true</code>.</li>
-          <li>If |a] and |b| are lists of [=atomic values=], both lists have the same length, and [=atomic values=] at the same position in |a| and |b| are [=equal=], return <code>true</code>.</li>
-          <li>Otherwise, return <code>false</code>.</li>
-        </ul>
-
-        <p>A [=chunk=] |A| <dfn data-lt="matching chunk">matches</dfn> [=chunk=] |B| if the conditions below are all met:</p>
-        <ul>
-          <li><i>Context</i>. One of the following conditions holds true:
-            <ul>
-              <li>Neither |A| nor |B| have [=@context=] properties.</li>
-              <li>Both |A| and |B| have [=@context=] properties and |A|'s [=@context=] property [=value=] [=equals=] |B|'s [=@context=] property [=value=].</li>
-            </ul>
-          </li>
-          <li><i>Identifier</i>. One of the following conditions holds true:
-            <ul>
-              <li>|A| has an [=@id=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=identifier=].</li>
-              <li>|A| does not have an [=@id=] property.</li>
-            </ul>
-          </li>
-          <li><i>Inheritance</i>. One of the following conditions holds true:
-            <ul>
-              <li>|A| has an [=@kindof=] property whose [=value=] |V| is an [=atomic value=], and |B|'s [=type=] is a subclass of |V|, meaning that |B|'s [=type=] is |V| or there exists a chain of <code>kindof</code> links between |V| and |B|'s [=type=].</li>
-              <li>|A| does not have an [=@kindof=] property.</li>
-            </ul>
-          </li>
-          <li><i>Properties</i>. For each [=property=] |p| in |A| whose [=name=] does not start with <code>@</code>, either of the following holds true:
-            <ul>
-              <li>|p|'s [=value=] is <code>!</code> and there is no [=property=] in |B| with |p|'s [=name=].</li>
-              <li>|p|'s [=value=] is not <code>!</code> and there exits a [=property=] in |B| with the same [=name=] and [=equal=] [=value=] as |p|.</li>
-            </ul>
-          </li>
-          <li><i>Type</i>. One of the following conditions holds true:
-            <ul>
-              <li>|A| has an [=@type=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=type=].</li>
-              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] is <code>*</code>.</li>
-              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] and |B|'s [=type=] are identical.</li>
-            </ul>
-          </li>
-        </ul>
-      </section>
-    </section>
-
-    <section>
-      <h3>Modules</h3>
-      <p>A <dfn>module</dfn> is a [=graph of chunks=] associated with one and only one [=module buffer=]. A [=module=] has a <dfn>module name</dfn> that follows the [=name=] data type, and that is typically used to target the [=module=] in [=@module=] properties.</p>
-
-      <p>A [=module=] supports [=built-in operations=], and may support additional operations defined by the application when the [=module=] is initialized.</p>
-      <p>A [=module=] represents a cognitive database on which the [=rule engine=] may operate. It may be viewed as a region in the cerebral cortex, where the [=module buffer=] corresponds to the bundle of nerve fibres connecting to that region.</p>
-
-      <p>The [=rule engine=] automatically creates a module named <code>goal</code>, which will therefore always exist in a rule execution context.</p>
-
-      <p>The [=@module=] property allows [=conditions=] and [=actions=] to reference the [=module name=] of the [=module=] they relate to. In the absence of an [=@module=] property, [=conditions=] and [=actions=] apply to the <code>goal</code> module.</p>
-
-      <section>
-        <h4>Module buffers</h4>
-        <p>A <dfn>module buffer</dfn> is a container for at most one [=chunk=]. The mammalian brain is richly connected locally, and weakly remotely. A [=module buffer=] mimics the constrained communication capacity of the mammalian brains for such long range communication.</p>
-
-        <p>The [=rule engine=] operates on a module's [=graph of chunks=] through its [=module buffer=].</p>
-
-        <p>A [=module buffer=] has a <dfn data-dfn-for="module buffer">status</dfn>, whose value is initially [=status/okay=], and which reflects the outcome of the last [=action=] held and performed by the [=module buffer=]. Values can be:</p>
-        <dl>
-          <dt><dfn><code>pending</code></dfn></dt>
-          <dd>The operation is still pending.</dd>
-          <dt><dfn><code>okay</code></dfn></dt>
-          <dd>The operation completed successfully.</dd>
-          <dd><p class="issue">Switch to <code>ok</code>? This seems more common in technologies (e.g. HTTP) than <code>okay</code>.</p></dd>
-          <dt><dfn><code>forbidden</code></dfn></dt>
-          <dd>The operation was not allowed.</dd>
-          <dt><dfn><code>nomatch</code></dfn></dt>
-          <dd>The operation failed because there was no [=matching chunk=] for the [=action=] in the targeted [=module=].</dd>
-          <dt><dfn><code>failed</code></dfn></dt>
-          <dd>The operation failed.</dd>
-        </dl>
-
-        <p>A [=module buffer=] has a <dfn>queue</dfn>, which is a set of [=chunks=], initially empty. Each chunk in the [=queue=] has a <dfn>priority</dfn>, represented by an integer from 1 to 10, with 10 the highest priority. The default [=priority=] is 5. [=Chunks=] are ordered by descending [=priority=] in a [=queue=]. When [=priorities=] match, [=chunks=] are ordered by insertion order (first in, first out).</p>
-
-        <p>The <dfn><code>@priority</code></dfn> property lets [=actions=] set the [=priority=] of a [=chunk=] when they add it to a [=queue=].</p>
-
-        <aside class="note" title="Queue and sub-goals">
-          <p>A [=queue=] may be useful to create sub-goals. For instance, whilst [=@do update=] operations allow applications to switch to a new goal, they may prefer [=rules=] to propose multiple sub-goals instead. [=Queues=] enable this through [=@do queue=] operations which push the [=chunk=] specified by an [=action=] to the [=queue=] of a [=module buffer=].</p>
-        </aside>
-
-        <p>A [=module buffer=] is automatically cleared when the [=actions=] associated with the [=rule=] it contained did not update the contents of targeted [=module buffers=]. This pops the [=queue=] if it is not already empty.</p>
-      </section>
-
-      <section>
-        <h4>Built-in operations</h4>
-        <p>The [=@do=] property lets an [=action=] specify the graph algorithm or operation to execute. The default operation is to update the [=module buffer=], similar to calling [=@do update=].</p>
-
-        <p>All [=modules=] support the <dfn>built-in operations</dfn> defined in this section.</p>
-
-        <p>All [=modules=] also support the [=@for=] property to iterate over a set of items in a comma separated list. This has the effect of loading the [=module buffer=] with the first item in the list. The index range can optionally be specified with [=@from=] and [=@to=], where the first item in the list has index <code>0</code>.</p>
-
-        <aside class="note" title="Application-defined operations">
-          <p>Applications can define additional operations when initialising a [=module=]. This can be used to perform a variety of operations, e.g. to allow rules to command a robot to move its arm, by passing it the desired position and direction of the robot's hand. Operations can be defined to allow messages to be spoken aloud or to support complex graph algorithms, e.g. for data analytics and machine learning.</p>
-
-          <p>Applications cannot replace the [=built-in operations=].</p>
-        </aside>
-        
-        <section>
-          <h5>The <dfn><code>@do clear</code></dfn> operation</h5>
-          <p>Clears the [=module buffer=] and pops the [=queue=].</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do delete</code></dfn> operation</h5>
-          <p>Forgets [=matching chunks=] in the [=graph of chunks=].</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do get</code></dfn> operation</h5>
-          <p>Looks for a [=matching chunk=] in the module's [=graph of chunks=] and puts a copy of it in the [=module buffer=] if found. Modifying the [=properties=] of a [=chunk=] copied from a [=graph of chunks=] (e.g. through a [=@do update=] operation) will not alter the underlying [=graph of chunks=]. To save an updated [=chunk=], a [=@do put=] or [=@do patch=] command needs to be issued.</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do next</code></dfn> operation</h5>
-          <p>Loads the next [=matching chunk=] to the targeted [=module buffer=] in an implementation dependent order.</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do patch</code></dfn> operation</h5>
-          <p>If the [=chunk=] in the targeted [=module buffer=] has the same [=identifier=] as a [=chunk=] in the underlying [=graph of chunks=], patches the [=chunk=] in the [=graph of chunks=] with the [=properties=] that appear in the [=module buffer=], excluding [=properties=] prefixed with an <code>@</code> character.</p>
-          <p class="issue">What is the expected behavior when the action has an <code>@id</code> property?</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do properties</code></dfn> operation</h5>
-          <p>Initiates an iteration over the [=properties=] of the [=matching chunk=] that do not begin with <code>@</code>. Each [=property=] is mapped to a new [=chunk=] with the same [=type=] as the [=action=]. The action's properties are copied over, and <code>name</code> and <code>value</code> properties are used to pass the [=property=] name and value respectively. The [=@more=] property is given the value <code>true</code> unless this is the final [=chunk=] in the iteration, in which case [=@more=] is given the value false. By default, the iteration is written to the same [=module buffer=] as designated by the [=action=] that initiated it. However, you can designate a different [=module buffer=] with the [=@to=] property. By setting additional properties in the initiating action, you can ensure that the rules used to process the property name and value are distinct from other such iterations.</p>
-          <aside class="example" title="Iterate over properties">
-            <p>The following example first sets the <code>facts</code> [=module buffer=] to a [=chunk=] of [=type=] <code>foo</code>, and then initiates an iteration over all of the [=chunk=]'s properties:</p>
-            <pre><code>run {}
-  =>
-    foo {@module facts; a 1; c 2}, # set facts buffer to foo {a 1; c 2}
-    bar {@module facts; @do properties; loop prop18; @to goal} # launch iteration
-    
-# this rule is invoked with the name and value for each property
-# note that 'loop prop18' is copied over from the initiating chunk
-# (also note that "@do log" is an hypothetical operation to log a message)
-bar {loop prop18; name ?name; value ?value}
-  =>
-    console {@do log; message ?name, is, ?value},
-    bar {@do next}  # to load the next instance from the iteration</code></pre>
-          </aside>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do put</code></dfn> operation</h5>
-          <p>Saves the contents of the [=module buffer=] as a [=chunk=] to the module's [=graph of chunks=]. If the [=action=] has an [=@id=] property, this operation will overwrite the [=chunk=] with the same [=identifier=] or will create a new [=chunk=] with the given [=identifier=] if it does not exist already. This operation will also create a new [=chunk=] in the absence of an [=@id=] property.</p>
-          <p class="issue">If a chunk was loaded with <code>@do get</code>, then updated with <code>@do update</code>, would a call to <code>@do patch</code> create a new chunk if <code>@id</code> is not set? Or would it rather update the chunk in the graph?</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do queue</code></dfn> operation</h5>
-          <p>Pushes a [=chunk=] to the [=queue=] for the [=module buffer=]. If a [=@priority=] property is set to an integer value between 1 and 10, the [=priority=] of the [=chunk=] in the [=queue=] is set to that value.</p>
-        </section>
-
-        <section>
-          <h5>The <dfn><code>@do update</code></dfn> operation</h5>
-          <p>Directly updates the [=module buffer=] if the chunk [=type=] for the [=action=] is the same as the [=chunk=] currently held in the [=module buffer=]. The operation updates the properties given in the [=action=], leaving aside properties prefixed with an <code>@</code> character, and leaving other existing properties unchanged. If the chunk [=type=] for the action is not the same as the [=chunk=] currently held in the [=module buffer=], a new [=chunk=] is created with the properties given in the [=action=], excluding properties prefixed with an <code>@</code> character. This is the default action when an [=action=] has neither an [=@do=] property nor an [=@for=] property.</p>
-          <p class="issue">How can one update the properties prefixed with an <code>@</code> character in a [=chunk=] such as [=@context=], [=@subject=] or [=@object=]?</p>
-        </section>
       </section>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
       <h3>Chunk properties</h3>
       <p>A chunk <dfn>property</dfn> is a [=name=]/[=value=] pair that describes a chunk across the particular dimension identified by the property name.</p>
 
-      <p>A <dfn>value</dfn> is either an [=atomic value=] or a list of [=atomic values=] (values are comma-separated in serialized form).</p>
+      <p>A <dfn>value</dfn> is either an [=atomic value=] or an ordered list of [=atomic values=] (values are comma-separated in serialized form).</p>
 
       <p>An <dfn>atomic value</dfn> is either:</p>
       <ul>
@@ -483,38 +483,43 @@ digits { @shift 0, @to list }</code></pre>
       <section>
         <h4>Matching chunks</h4>
 
-        <p>A [=chunk=] |B| is said to be a <dfn data-lt="matches">matching chunk</dfn> for a [=chunk=] |A| if the conditions below are all met:</p>
+        <p>A property [=value=] |a| <dfn>equals</dfn> property [=value=] |b| if either of the following conditions holds true:</p>
+        <ul>
+          <li>|a| and |b| are identical [=atomic values=]</li>
+          <li>|a] and |b| are lists of [=atomic values=], both lists have the same length, and [=atomic values=] at the same position in |a| and |b| are identical.</li>
+        </ul>
+
+        <p>A [=chunk=] |A| <dfn data-lt="matching chunk">matches</dfn> [=chunk=] |B| if the conditions below are all met:</p>
         <ul>
           <li><i>Context</i>. One of the following conditions holds true:
             <ul>
               <li>Neither |A| nor |B| have [=@context=] properties.</li>
-              <li>Both |A| and |B| have [=@context=] properties and |A|'s [=@context=] property [=value=] equals |B|'s [=@context=] property [=value=].</li>
+              <li>Both |A| and |B| have [=@context=] properties and |A|'s [=@context=] property [=value=] [=equals=] |B|'s [=@context=] property [=value=].</li>
             </ul>
           </li>
           <li><i>Identifier</i>. One of the following conditions holds true:
             <ul>
-              <li>|A| has an [=@id=] property whose [=value=] equals |B|'s [=identifier=].</li>
+              <li>|A| has an [=@id=] property whose [=value=] is an [=atomic value=] that equals |B|'s [=identifier=].</li>
               <li>|A| does not have an [=@id=] property.</li>
             </ul>
           </li>
           <li><i>Inheritance</i>. One of the following conditions holds true:
             <ul>
-              <li>|A| has an [=@kindof=] property whose [=value=] is |V|, and |B|'s [=type=] is a subclass of |V|, meaning that |B|'s [=type=] equals |V| or there exists a chain of <code>kindof</code> links between |V| and |B|'s [=type=].</li>
+              <li>|A| has an [=@kindof=] property whose [=value=] |V| is an [=atomic value=], and |B|'s [=type=] is a subclass of |V|, meaning that |B|'s [=type=] is |V| or there exists a chain of <code>kindof</code> links between |V| and |B|'s [=type=].</li>
               <li>|A| does not have an [=@kindof=] property.</li>
             </ul>
           </li>
-          <li><i>Properties</i>. For all [=properties=] in |A| whose [=names=] do not start with <code>@</code>, there is a corresponding [=property=] in |B| with the same [=name=] and [=value=].</li>
+          <li><i>Properties</i>. For all [=properties=] in |A| whose [=names=] do not start with <code>@</code>, there is a corresponding [=property=] in |B| with the same [=name=] and [=equal=] [=value=].</li>
           <li><i>Type</i>. One of the following conditions holds true:
             <ul>
-              <li>|A| has an [=@type=] property whose [=value=] equals |B|'s [=type=].</li>
+              <li>|A| has an [=@type=] property whose [=value=] is an [=atomic value=] that equals |B|'s [=type=].</li>
               <li>|A| does not have an [=@type=] property, and |A|'s [=type=] is <code>*</code>.</li>
-              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] equals |B|'s [=type=].</li>
+              <li>|A| does not have an [=@type=] property, and |A|'s [=type=] and |B|'s [=type=] are identical.</li>
             </ul>
           </li>
         </ul>
 
         <p class="ednote">TODO: Rewrite and complete to integrate [=variables=] (which impose presence but not a specific value) and <code>~</code> which match when values are not equal or, if <code>~</code> is used alone, when the property is undefined.</p>
-        <p class="ednote">TODO: Also explain what happens when values being compared are not [=atomic values=].</p>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
     <ul>
       <li><code>@</code> to denote a <dfn>reserved name</dfn> with specific meaning (defined in this specification). Such [=names=] may only appear as [=property=] names.</li>
       <li><code>?</code> to denote a [=variable=]. Such [=names=] may only appear as [=property=] values.</li>
-      <li><code>~</code> to denote a negative match. Such [=names=] may only appear in property [=values=] of a rule [=condition=]. The <code>~</code> prefix may be followed by <code>?</code> to reference a [=variable=]. Also, the [=name=] may actually equal <code>~</code> to test that a [=property=] is undefined.</li>
+      <li><code>!</code> to [=negate=] a match. The <code>!</code> prefix may be followed by <code>?</code> to reference a [=variable=]. Also, the [=name=] may actually equal <code>!</code> to test that a [=property=] is undefined.</li>
     </ul>
   </section>
 </section>
@@ -330,15 +330,120 @@ memory a2 { @module facts }</code></pre>
       <section>
         <h4>Variables</h4>
 
-        <p>A <dfn>variable</dfn> is a [=name=] that starts with <code>?</code> that represents a symbolic name to a [=value=]. A [=value=] gets bound to a [=variable=] in [=conditions=]. The [=value=] can then be referenced in [=actions=] using the [=variable=]'s name. Effectively, [=variables=] allow applications to copy information from rule [=conditions=] to rule [=actions=].</p>
+        <p>A <dfn>variable</dfn> is a [=name=] that starts with <code>?</code> that represents a symbolic name to a [=value=]. A [=variable=] gets <dfn>bound</dfn> to a [=value=] in [=conditions=]. The [=value=] can then be referenced in [=actions=] using the [=variable=]'s name. Effectively, [=variables=] allow applications to copy information from rule [=conditions=] to rule [=actions=].</p>
 
-        <p>[=Variables=] are scoped to the [=rule=] where they appear. They may represent any type of [=value=].</p>
+        <p>[=Variables=] are scoped to the [=rule=] where they appear.</p>
 
         <aside class="example" title="Variable binding and referencing">
           <pre><code>count { state start; from ?num1; to ?num2 }
-   => increment { @module facts; @do get; number ?num1 }</code></pre>
+  => increment { @module facts; @do get; number ?num1 }</code></pre>
           <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=]. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk, and the value of the [=variable=] <code>?num2</code> to the [=value=] of the <code>to</code> [=property=].</p>
           <p>The [=rule=] defines an [=action=] that looks for a [=chunk=] in the <code>facts</code> [=module=] whose [=type=] is <code>increment</code> and that has a [=property=] named <code>number</code> and whose [=value=] equals the value of the <code>?num1</code> [=variable=].</p>
+        </aside>
+
+        <p>[=Variables=] are [=bound=] to a [=value=] the first time they appear in a [=condition=]. Subsequent occurrences of the same [=variable=] in a [=condition=] reference their [=value=].</p>
+
+        <aside class="example" title="Variable binding and referencing in the same condition">
+          <pre><code>count { state start; from ?num1; to ?num1 }
+  => console { @do log; message ?num1 }</code></pre>
+          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>count</code>, that has a <code>state</code> [=property=] whose value is <code>start</code>, and that has <code>from</code> and <code>to</code> [=properties=] that have identical values. The [=condition=] binds the value of the [=variable=] <code>?num1</code> to the [=value=] of the <code>from</code> [=property=] in the matching chunk.</p>
+        </aside>
+
+        <p>[=Variables=] may represent any type of [=value=]. In particular, a [=variable=] that [=matches=] a property whose value is a list of [=atomic values=] gets bound to the list of [=atomic values=].</p>
+
+        <aside class="example" title="Variable binding to a list of atomic values">
+          <pre><code>basket { fruit ?f }
+  => console { @do log; message ?f }</code></pre>
+          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=]. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?f</code> to <code>apple, banana, orange</code>:</p>
+          <pre><code>basket { fruit apple, banana, orange }</code></pre>
+        </aside>
+
+        <p>A [=condition=] that contains a [=property=] with a list of [=variables=] [=matches=] a list of [=atomic values=] that has the same length. The [=condition=] does not [=match=] when the lengths of the lists differ.</p>
+
+        <aside class="example" title="Variable binding to atomic values in a list">
+          <pre><code>basket { fruit ?a, ?b, ?o }
+  => console { @do log; message ?a, ?b, ?o }</code></pre>
+          <p>The above [=rule=] defines a [=condition=] that [=matches=] a [=chunk=] in the <code>goal</code> [=module buffer=] whose [=type=] is <code>basket</code> and that has a <code>fruit</code> [=property=] whose value is a list of <em>three</em> atomic values. Given the following [=chunk=] in the <code>goal</code> [=module buffer=], the [=condition=] binds variable <code>?a</code> to <code>apple</code>, <code>?b</code> to <code>banana</code>, and <code>?o</code> to <code>orange</code>:</p>
+          <pre><code>basket { fruit apple, banana, orange }</code></pre>
+        </aside>
+      </section>
+
+      <section>
+        <h4>The negation operator <code>!</code></h4>
+        <p>The <dfn data-lt="negative operation">negation operator</dfn> <code>!</code> may be prepended to [=names=] to <dfn>negate</dfn> the outcome of their evaluation. The [=negation operator=] may be used in one of the following cases:</p>
+        <ul>
+          <li>
+            In a [=rule=] in front of a [=condition=] to negate it. A rule with a negated [=condition=] !|cond| applies if and only if |cond| does not hold true.
+            <aside class="example" title="Negate a rule condition">
+              <pre><code># Rule with a negated condition
+rule {
+  @condition !c1
+  @action a1
+}
+person c1 { @id John }
+console a1 { @do log; message "Type is not person or id is not John" }
+
+# Same rule defined using the compact format
+!person { @id John }
+  => console { @do log; message "Type is not person or id is not John" }</code></pre>
+              <p>The above example illustrates two equivalent ways to define a rule with a negated condition. In this example, the condition |c1| [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <code>John</code>. As such, the negated condition [=matches=] a [=chunk=] whose [=type=] is <em>not</em> <code>person</code> <em>or</em> whose [=identifier=] is <em>not</em> <code>John</code>.</p>
+            </aside>
+          </li>
+          <li>
+            In a [=condition=] in front of a [=property=] value to negate the result of a [=match=]. A negated [=property=] value !|val1| [=equals=] another [=property=] value |val2| if and only if |val1| does not [=equal=] |val2|.
+            <aside class="example" title="Negate a value match">
+              <pre><code>person { @id !John }
+  => console { @do log; message "Type is person but id is not John" }</code></pre>
+              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>person</code> and whose [=identifier=] is <em>not</em> <code>John</code>.</p>
+            </aside>
+            <aside class="example" title="Negate an atomic value in a list">
+              <pre><code>basket { fruit ?a, !banana, ?o }
+  => console { @do log; message "No banana in second position" }</code></pre>
+              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which has a <code>fruit</code> [=property=] whose [=value=] is a list of three [=atomic values=]. First and third [=atomic values=] in that list can be anything. Second [=atomic value=] must <em>not</em> be <code>banana</code>.</p>
+            </aside>
+          </li>
+          <li>
+            On its own as a [=property=] value in a [=condition=] to test that a [=property=] is undefined. A [=condition=] with a [=property=] |p| whose value is <code>!</code> [=matches=] a [=chunk=] if and only if the [=chunk=] does not have a [=property=] whose [=name=] is |p|'s [=name=].
+            <aside class="example" title="Test that a property is undefined">
+              <pre><code>basket { fruit ! }
+  => console { @do log; message "Basket without fruits" }</code></pre>
+              <p>The above [=condition=] [=matches=] a [=chunk=] whose [=type=] is <code>basket</code> and which does not have a <code>fruit</code> [=property=].</p>
+            </aside>
+          </li>
+          <li>
+            On its own as a [=property=] value in a [=@do patch=], [=@do update=] or similar [=action=] that updates a [=chunk=] to unset a [=property=].
+            <aside class="example" title="Unset a chunk property">
+              <pre><code># Given the following chunk in the module buffer
+basket { fruit apple, banana, orange }
+
+# ... the following rule drops the fruit property
+* {} => basket { @do update; fruit ! }
+
+# Resulting chunk
+basket {}</code></pre>
+            </aside>
+          </li>
+        </ul>
+
+        <p>The [=negation operator=] cannot be prepended to a [=variable=] that has not yet been [=bound=]. Similarly, the [=negation operator=] cannot be used on its own as an [=atomic value=] in a list. More generally, the [=negation operator=] cannot be used elsewhere than in the cases detailed above.</p>
+        <aside class="example" title="Some invalid uses of the negation operator">
+          <pre><code># Invalid: variable ?num1 is unbound
+count { state counting; start !?num1 } => ...
+
+# Invalid: on its own in a list
+basket { fruit ?a, !, ?o } => ...
+
+# Invalid: in an update action but not on its own
+* {} => basket { @do update; fruit !apple }</code></pre>
+        </aside>
+
+        <p>A second [=negation operator=] prepended to a [=name=] that starts with a [=negation operator=] cancels the effect of the first [=negation operator=].</p>
+        <aside class="example" title="Double negation">
+          <pre><code># The following condition
+person { @id !!John }
+
+# ... is the same as this one:
+person { @id John }</code></pre>
         </aside>
       </section>
 
@@ -483,10 +588,19 @@ digits { @shift 0, @to list }</code></pre>
       <section>
         <h4>Matching chunks</h4>
 
-        <p>A property [=value=] |a| <dfn>equals</dfn> property [=value=] |b| if either of the following conditions holds true:</p>
+        <p>A property [=value=] |a| <dfn>equals</dfn> property [=value=] |b| when the following algorithm returns <code>true</code>:</p>
         <ul>
-          <li>|a| and |b| are identical [=atomic values=]</li>
-          <li>|a] and |b| are lists of [=atomic values=], both lists have the same length, and [=atomic values=] at the same position in |a| and |b| are identical.</li>
+          <li>If |a| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
+          <li>If |b| is the [=negation operator=] <code>!</code>, return <code>false</code>.</li>
+          <li>If |a| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if !|a| [=equals=] |b|, <code>true</code> otherwise.</li>
+          <li>If |b| is a [=name=] that starts with the [=negation operator=] <code>!</code>, return <code>false</code> if |a| [=equals=] !|b|, <code>true</code> otherwise.</li>
+          <li>If |a| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
+          <li>If |b| is a [=variable=] that is not yet [=bound=] to a value, return <code>true</code>.</li>
+          <li>If |a| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |v| [=equals=] |b|, <code>false</code> otherwise.</li>
+          <li>If |b| is a [=variable=] [=bound=] to a value |v|, return <code>true</code> if |a| [=equals=] |v|, <code>false</code> otherwise.</li>
+          <li>If |a| and |b| are identical [=atomic values=], return <code>true</code>.</li>
+          <li>If |a] and |b| are lists of [=atomic values=], both lists have the same length, and [=atomic values=] at the same position in |a| and |b| are [=equal=], return <code>true</code>.</li>
+          <li>Otherwise, return <code>false</code>.</li>
         </ul>
 
         <p>A [=chunk=] |A| <dfn data-lt="matching chunk">matches</dfn> [=chunk=] |B| if the conditions below are all met:</p>
@@ -499,7 +613,7 @@ digits { @shift 0, @to list }</code></pre>
           </li>
           <li><i>Identifier</i>. One of the following conditions holds true:
             <ul>
-              <li>|A| has an [=@id=] property whose [=value=] is an [=atomic value=] that equals |B|'s [=identifier=].</li>
+              <li>|A| has an [=@id=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=identifier=].</li>
               <li>|A| does not have an [=@id=] property.</li>
             </ul>
           </li>
@@ -509,17 +623,20 @@ digits { @shift 0, @to list }</code></pre>
               <li>|A| does not have an [=@kindof=] property.</li>
             </ul>
           </li>
-          <li><i>Properties</i>. For all [=properties=] in |A| whose [=names=] do not start with <code>@</code>, there is a corresponding [=property=] in |B| with the same [=name=] and [=equal=] [=value=].</li>
+          <li><i>Properties</i>. For each [=property=] |p| in |A| whose [=name=] does not start with <code>@</code>, either of the following holds true:
+            <ul>
+              <li>|p|'s [=value=] is <code>!</code> and there is no [=property=] in |B| with |p|'s [=name=].</li>
+              <li>|p|'s [=value=] is not <code>!</code> and there exits a [=property=] in |B| with the same [=name=] and [=equal=] [=value=] as |p|.</li>
+            </ul>
+          </li>
           <li><i>Type</i>. One of the following conditions holds true:
             <ul>
-              <li>|A| has an [=@type=] property whose [=value=] is an [=atomic value=] that equals |B|'s [=type=].</li>
+              <li>|A| has an [=@type=] property whose [=value=] is an [=atomic value=] that [=equals=] |B|'s [=type=].</li>
               <li>|A| does not have an [=@type=] property, and |A|'s [=type=] is <code>*</code>.</li>
               <li>|A| does not have an [=@type=] property, and |A|'s [=type=] and |B|'s [=type=] are identical.</li>
             </ul>
           </li>
         </ul>
-
-        <p class="ednote">TODO: Rewrite and complete to integrate [=variables=] (which impose presence but not a specific value) and <code>~</code> which match when values are not equal or, if <code>~</code> is used alone, when the property is undefined.</p>
       </section>
     </section>
 


### PR DESCRIPTION
The update also clarifies that the order of atomic values in a list is significant.

Note that the `@kindof` operator will only match if its value is an atomic value. Rule may change in the future if that seems too strict.

Fixes #30 and #36.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/cogai/pull/37.html" title="Last updated on Jun 29, 2021, 5:12 PM UTC (2a16d76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/cogai/37/8e56578...2a16d76.html" title="Last updated on Jun 29, 2021, 5:12 PM UTC (2a16d76)">Diff</a>